### PR TITLE
feat: add light theme with user selectable preference

### DIFF
--- a/app/(app)/add-url/[...params].tsx
+++ b/app/(app)/add-url/[...params].tsx
@@ -4,9 +4,10 @@ import { View, StyleSheet, Alert } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 
 import { Header, Input, Button } from '@/components/ui'
-import { Colors } from '@/constants/Colors'
+import { type ThemeColors } from '@/constants/Colors'
 import { Spacing } from '@/constants/Layout'
 import { useApp } from '@/context/AppContext'
+import { useThemeColors } from '@/hooks/useThemeColors'
 
 export default function AddUrlScreen() {
   const [url, setUrl] = useState('')
@@ -50,6 +51,9 @@ export default function AddUrlScreen() {
 
     router.back()
   }
+
+  const colors = useThemeColors()
+  const styles = React.useMemo(() => createStyles(colors), [colors])
 
   if (!item) {
     return (
@@ -100,28 +104,29 @@ export default function AddUrlScreen() {
   )
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: Colors.background,
-  },
+const createStyles = (colors: ThemeColors) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: colors.background,
+    },
 
-  content: {
-    flex: 1,
-    padding: Spacing.screenPadding,
-    justifyContent: 'space-between',
-  },
+    content: {
+      flex: 1,
+      padding: Spacing.screenPadding,
+      justifyContent: 'space-between',
+    },
 
-  buttonContainer: {
-    paddingBottom: Spacing.xl,
-  },
+    buttonContainer: {
+      paddingBottom: Spacing.xl,
+    },
 
-  buttonRow: {
-    flexDirection: 'row',
-    gap: Spacing.md,
-  },
+    buttonRow: {
+      flexDirection: 'row',
+      gap: Spacing.md,
+    },
 
-  button: {
-    flex: 1,
-  },
-})
+    button: {
+      flex: 1,
+    },
+  })

--- a/app/(app)/list/[id].tsx
+++ b/app/(app)/list/[id].tsx
@@ -1,6 +1,6 @@
 import { Ionicons } from '@expo/vector-icons'
 import { useRouter, useLocalSearchParams, Stack } from 'expo-router'
-import React from 'react'
+import React, { useMemo } from 'react'
 import {
   View,
   Text,
@@ -14,10 +14,11 @@ import { Swipeable } from 'react-native-gesture-handler'
 import { SafeAreaView } from 'react-native-safe-area-context'
 
 import { EmptyState, Button, Checkbox, ProgressChip } from '@/components/ui'
-import { Colors } from '@/constants/Colors'
+import { type ThemeColors } from '@/constants/Colors'
 import { Spacing } from '@/constants/Layout'
 import { Typography } from '@/constants/Typography'
 import { useApp } from '@/context/AppContext'
+import { useThemeColors } from '@/hooks/useThemeColors'
 import { ShoppingItem } from '@/types'
 
 export default function ListDetailScreen() {
@@ -27,6 +28,8 @@ export default function ListDetailScreen() {
 
   const { getList, dispatch } = useApp()
   const list = getList(listId)
+  const colors = useThemeColors()
+  const styles = useMemo(() => createStyles(colors), [colors])
 
   const completedCount = list
     ? list.items.filter(item => item.isCompleted).length
@@ -88,7 +91,7 @@ export default function ListDetailScreen() {
               onPress={() => router.back()}
               style={styles.backButton}
             >
-              <Ionicons name="chevron-back" size={24} color={Colors.text} />
+              <Ionicons name="chevron-back" size={24} color={colors.text} />
             </TouchableOpacity>
 
             <Text style={styles.headerTitle} numberOfLines={1}>
@@ -158,7 +161,7 @@ export default function ListDetailScreen() {
           )
         }}
       >
-        <Ionicons name="trash-outline" size={20} color={Colors.text} />
+        <Ionicons name="trash-outline" size={20} color={colors.text} />
       </TouchableOpacity>
     </View>
   )
@@ -185,7 +188,7 @@ export default function ListDetailScreen() {
             <Ionicons
               name="link-outline"
               size={18}
-              color={hasUrl ? Colors.primary : '#585858'}
+              color={hasUrl ? colors.primary : colors.textSecondary}
             />
           </TouchableOpacity>
 
@@ -263,7 +266,7 @@ export default function ListDetailScreen() {
               onPress={() => router.back()}
               style={styles.backButton}
             >
-              <Ionicons name="chevron-back" size={24} color={Colors.text} />
+              <Ionicons name="chevron-back" size={24} color={colors.text} />
             </TouchableOpacity>
 
             <Text style={styles.headerTitle} numberOfLines={1}>
@@ -304,7 +307,7 @@ export default function ListDetailScreen() {
                 <Ionicons
                   name="ellipsis-horizontal"
                   size={24}
-                  color={Colors.text}
+                  color={colors.text}
                 />
               </TouchableOpacity>
             </View>
@@ -341,7 +344,7 @@ export default function ListDetailScreen() {
             onPress={() => router.back()}
             style={styles.backButton}
           >
-            <Ionicons name="chevron-back" size={24} color={Colors.text} />
+            <Ionicons name="chevron-back" size={24} color={colors.text} />
           </TouchableOpacity>
 
           <Text style={styles.headerTitle} numberOfLines={1}>
@@ -378,7 +381,7 @@ export default function ListDetailScreen() {
               <Ionicons
                 name="ellipsis-horizontal"
                 size={24}
-                color={Colors.text}
+                color={colors.text}
               />
             </TouchableOpacity>
           </View>
@@ -406,159 +409,160 @@ export default function ListDetailScreen() {
   )
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: Colors.background,
-  },
+const createStyles = (colors: ThemeColors) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: colors.background,
+    },
 
-  customHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    height: 56,
-    paddingHorizontal: 24,
-    backgroundColor: Colors.background,
-  },
+    customHeader: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      height: 56,
+      paddingHorizontal: 24,
+      backgroundColor: colors.background,
+    },
 
-  backButton: {
-    width: 44,
-    height: 44,
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginLeft: -12,
-  },
+    backButton: {
+      width: 44,
+      height: 44,
+      alignItems: 'center',
+      justifyContent: 'center',
+      marginLeft: -12,
+    },
 
-  headerTitle: {
-    fontSize: 24,
-    fontWeight: Typography.fontWeight.semibold,
-    color: Colors.text,
-    flex: 1,
-    marginLeft: 12,
-    marginRight: 16,
-  },
+    headerTitle: {
+      fontSize: 24,
+      fontWeight: Typography.fontWeight.semibold,
+      color: colors.text,
+      flex: 1,
+      marginLeft: 12,
+      marginRight: 16,
+    },
 
-  headerRight: {
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
+    headerRight: {
+      flexDirection: 'row',
+      alignItems: 'center',
+    },
 
-  menuButton: {
-    width: 44,
-    height: 44,
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginLeft: 8,
-  },
+    menuButton: {
+      width: 44,
+      height: 44,
+      alignItems: 'center',
+      justifyContent: 'center',
+      marginLeft: 8,
+    },
 
-  content: {
-    flex: 1,
-    padding: 24, // 24pt页面左右安全间距
-  },
+    content: {
+      flex: 1,
+      padding: 24, // 24pt页面左右安全间距
+    },
 
-  shareSection: {
-    marginBottom: Spacing.lg,
-  },
+    shareSection: {
+      marginBottom: Spacing.lg,
+    },
 
-  shareLabel: {
-    fontSize: 17, // 17pt小节标题
-    fontWeight: Typography.fontWeight.semibold,
-    color: Colors.text,
-    opacity: 0.7, // #FFF 70%
-  },
+    shareLabel: {
+      fontSize: 17, // 17pt小节标题
+      fontWeight: Typography.fontWeight.semibold,
+      color: colors.text,
+      opacity: 0.7, // #FFF 70%
+    },
 
-  listContainer: {
-    flexGrow: 1,
-    paddingBottom: Spacing.lg,
-  },
+    listContainer: {
+      flexGrow: 1,
+      paddingBottom: Spacing.lg,
+    },
 
-  itemContainer: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: Colors.surface,
-    borderRadius: 20, // 20-22pt卡片圆角
-    marginBottom: 16, // 16pt卡片间距
-    paddingHorizontal: 16, // 水平16pt
-    paddingVertical: 14, // 垂直14pt
-  },
+    itemContainer: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      backgroundColor: colors.surface,
+      borderRadius: 20, // 20-22pt卡片圆角
+      marginBottom: 16, // 16pt卡片间距
+      paddingHorizontal: 16, // 水平16pt
+      paddingVertical: 14, // 垂直14pt
+    },
 
-  itemLeftIcons: {
-    width: 36, // 固定宽度
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingRight: 12, // 右侧间距
-  },
+    itemLeftIcons: {
+      width: 36, // 固定宽度
+      alignItems: 'center',
+      justifyContent: 'center',
+      paddingRight: 12, // 右侧间距
+    },
 
-  itemContent: {
-    flex: 1,
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
+    itemContent: {
+      flex: 1,
+      flexDirection: 'row',
+      alignItems: 'center',
+    },
 
-  emojiIcon: {
-    fontSize: 18,
-    lineHeight: 20,
-    marginRight: 12,
-  },
+    emojiIcon: {
+      fontSize: 18,
+      lineHeight: 20,
+      marginRight: 12,
+    },
 
-  completedEmoji: {
-    opacity: 0.5, // 完成态降低透明度，与completedText一致
-  },
+    completedEmoji: {
+      opacity: 0.5, // 完成态降低透明度，与completedText一致
+    },
 
-  defaultIconContainer: {
-    width: 20,
-    height: 20,
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: 'transparent',
-    marginRight: 12,
-  },
+    defaultIconContainer: {
+      width: 20,
+      height: 20,
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: 'transparent',
+      marginRight: 12,
+    },
 
-  defaultIcon: {
-    width: 24,
-    height: 24,
-  },
+    defaultIcon: {
+      width: 24,
+      height: 24,
+    },
 
-  itemTextContainer: {
-    flex: 1,
-  },
+    itemTextContainer: {
+      flex: 1,
+    },
 
-  itemText: {
-    flex: 1,
-    fontSize: 17, // 17pt名称字号
-    fontWeight: Typography.fontWeight.semibold,
-    color: Colors.text,
-  },
+    itemText: {
+      flex: 1,
+      fontSize: 17, // 17pt名称字号
+      fontWeight: Typography.fontWeight.semibold,
+      color: colors.text,
+    },
 
-  completedText: {
-    opacity: 0.5, // 完成态降低透明度
-  },
+    completedText: {
+      opacity: 0.5, // 完成态降低透明度
+    },
 
-  rightActionsContainer: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingVertical: 14, // 与itemContainer完全相同的paddingVertical
-    marginBottom: 16, // 与itemContainer完全相同的marginBottom
-  },
+    rightActionsContainer: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingVertical: 14, // 与itemContainer完全相同的paddingVertical
+      marginBottom: 16, // 与itemContainer完全相同的marginBottom
+    },
 
-  deleteAction: {
-    backgroundColor: Colors.error,
-    justifyContent: 'center',
-    alignItems: 'center',
-    width: 60,
-    height: 46, // 计算出的纯内容高度（不含padding）
-    borderRadius: 20,
-    marginLeft: 8,
-  },
+    deleteAction: {
+      backgroundColor: colors.error,
+      justifyContent: 'center',
+      alignItems: 'center',
+      width: 60,
+      height: 46, // 计算出的纯内容高度（不含padding）
+      borderRadius: 20,
+      marginLeft: 8,
+    },
 
-  hint: {
-    ...Typography.textStyles.caption,
-    color: Colors.textTertiary,
-    textAlign: 'center',
-    marginBottom: Spacing.lg,
-  },
+    hint: {
+      ...Typography.textStyles.caption,
+      color: colors.textTertiary,
+      textAlign: 'center',
+      marginBottom: Spacing.lg,
+    },
 
-  emptyImage: {
-    width: 180,
-    height: 120,
-  },
-})
+    emptyImage: {
+      width: 180,
+      height: 120,
+    },
+  })

--- a/app/(app)/lists.tsx
+++ b/app/(app)/lists.tsx
@@ -1,6 +1,6 @@
 import { Ionicons } from '@expo/vector-icons'
 import { useRouter } from 'expo-router'
-import React, { useState } from 'react'
+import React, { useState, useMemo } from 'react'
 import {
   View,
   Text,
@@ -22,10 +22,11 @@ import {
   FadeInListItem,
   Input,
 } from '@/components/ui'
-import { Colors } from '@/constants/Colors'
+import { type ThemeColors } from '@/constants/Colors'
 import { Spacing, BorderRadius, Shadows } from '@/constants/Layout'
 import { Typography } from '@/constants/Typography'
 import { useApp } from '@/context/AppContext'
+import { useThemeColors } from '@/hooks/useThemeColors'
 import { ShoppingList } from '@/types'
 import { HapticFeedback } from '@/utils/haptics'
 
@@ -35,6 +36,8 @@ export default function ListsScreen() {
   const router = useRouter()
   const { getVisibleLists, dispatch } = useApp()
   const allLists = getVisibleLists()
+  const colors = useThemeColors()
+  const styles = useMemo(() => createStyles(colors), [colors])
 
   // Filter lists based on search text
   const filteredLists =
@@ -171,7 +174,7 @@ export default function ListsScreen() {
               <Ionicons
                 name="copy-outline"
                 size={16}
-                color={Colors.textSecondary}
+                color={colors.textSecondary}
               />
               <Text style={styles.actionText} numberOfLines={1}>
                 Duplicate
@@ -185,7 +188,7 @@ export default function ListsScreen() {
               <Ionicons
                 name="archive-outline"
                 size={16}
-                color={Colors.textSecondary}
+                color={colors.textSecondary}
               />
               <Text style={styles.actionText} numberOfLines={1}>
                 Archive
@@ -199,7 +202,7 @@ export default function ListsScreen() {
               <Ionicons
                 name="trash-outline"
                 size={16}
-                color={Colors.textSecondary}
+                color={colors.textSecondary}
               />
               <Text style={styles.actionText} numberOfLines={1}>
                 Delete
@@ -224,7 +227,7 @@ export default function ListsScreen() {
               <Ionicons
                 name={isSearchVisible ? 'close' : 'search'}
                 size={24}
-                color={Colors.text}
+                color={colors.text}
               />
             </TouchableOpacity>
           }
@@ -233,7 +236,7 @@ export default function ListsScreen() {
               style={styles.headerButton}
               onPress={handleShowSettings}
             >
-              <Ionicons name="settings-outline" size={24} color={Colors.text} />
+              <Ionicons name="settings-outline" size={24} color={colors.text} />
             </TouchableOpacity>
           }
         />
@@ -269,7 +272,7 @@ export default function ListsScreen() {
             <Ionicons
               name={isSearchVisible ? 'close' : 'search'}
               size={24}
-              color={Colors.text}
+              color={colors.text}
             />
           </TouchableOpacity>
         }
@@ -278,7 +281,7 @@ export default function ListsScreen() {
             style={styles.headerButton}
             onPress={handleShowSettings}
           >
-            <Ionicons name="settings-outline" size={24} color={Colors.text} />
+            <Ionicons name="settings-outline" size={24} color={colors.text} />
           </TouchableOpacity>
         }
       />
@@ -291,7 +294,7 @@ export default function ListsScreen() {
             placeholder="Search lists or items..."
             autoFocus
             leftIcon={
-              <Ionicons name="search" size={20} color={Colors.textSecondary} />
+              <Ionicons name="search" size={20} color={colors.textSecondary} />
             }
             rightIcon={
               searchText.length > 0 ? (
@@ -299,7 +302,7 @@ export default function ListsScreen() {
                   <Ionicons
                     name="close-circle"
                     size={20}
-                    color={Colors.textSecondary}
+                    color={colors.textSecondary}
                   />
                 </TouchableOpacity>
               ) : undefined
@@ -317,7 +320,7 @@ export default function ListsScreen() {
               <Ionicons
                 name="search-outline"
                 size={48}
-                color={Colors.textTertiary}
+                color={colors.textTertiary}
               />
             }
             action={
@@ -346,98 +349,99 @@ export default function ListsScreen() {
   )
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: Colors.background,
-  },
+const createStyles = (colors: ThemeColors) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: colors.background,
+    },
 
-  emptyContainer: {
-    flex: 1,
-  },
+    emptyContainer: {
+      flex: 1,
+    },
 
-  searchContainer: {
-    paddingHorizontal: Spacing.screenPadding,
-    paddingVertical: Spacing.md,
-    backgroundColor: Colors.background,
-  },
+    searchContainer: {
+      paddingHorizontal: Spacing.screenPadding,
+      paddingVertical: Spacing.md,
+      backgroundColor: colors.background,
+    },
 
-  listContainer: {
-    padding: 24, // 24pt页面左右安全间距
-    paddingBottom: 100, // Space for FAB
-  },
+    listContainer: {
+      padding: 24, // 24pt页面左右安全间距
+      paddingBottom: 100, // Space for FAB
+    },
 
-  listCard: {
-    backgroundColor: Colors.surface,
-    borderRadius: 20, // 20-22pt卡片圆角
-    marginBottom: 16, // 16pt卡片垂直间距
-    ...Shadows.medium,
-  },
+    listCard: {
+      backgroundColor: colors.surface,
+      borderRadius: 20, // 20-22pt卡片圆角
+      marginBottom: 16, // 16pt卡片垂直间距
+      ...Shadows.medium,
+    },
 
-  listCardContent: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    padding: 20, // 减少内边距，从24pt到20pt
-    paddingBottom: 12, // 减少底部间距
-  },
+    listCardContent: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      padding: 20, // 减少内边距，从24pt到20pt
+      paddingBottom: 12, // 减少底部间距
+    },
 
-  listCardLeft: {
-    flex: 1,
-  },
+    listCardLeft: {
+      flex: 1,
+    },
 
-  listCardRight: {
-    marginLeft: 16,
-  },
+    listCardRight: {
+      marginLeft: 16,
+    },
 
-  listTitle: {
-    ...Typography.textStyles.subtitle,
-    color: Colors.text,
-    marginBottom: 8,
-    fontWeight: Typography.fontWeight.semibold,
-  },
+    listTitle: {
+      ...Typography.textStyles.subtitle,
+      color: colors.text,
+      marginBottom: 8,
+      fontWeight: Typography.fontWeight.semibold,
+    },
 
-  listPreview: {
-    fontSize: 15, // 15-16pt预览文案字号
-    color: '#B5B5B5', // Figma指定的预览文案颜色
-    lineHeight: 20,
-  },
+    listPreview: {
+      fontSize: 15, // 15-16pt预览文案字号
+      color: colors.textSecondary,
+      lineHeight: 20,
+    },
 
-  listActions: {
-    flexDirection: 'row', // 横排
-    paddingHorizontal: 20, // 减少水平padding
-    paddingTop: 8, // 减少顶部间距
-    paddingBottom: 16,
-    justifyContent: 'space-between', // 平均分布
-  },
+    listActions: {
+      flexDirection: 'row', // 横排
+      paddingHorizontal: 20, // 减少水平padding
+      paddingTop: 8, // 减少顶部间距
+      paddingBottom: 16,
+      justifyContent: 'space-between', // 平均分布
+    },
 
-  actionButton: {
-    flexDirection: 'row', // 图标+文字横排
-    alignItems: 'center',
-    flex: 1, // 平均占用空间
-    justifyContent: 'center', // 居中对齐
-    paddingHorizontal: 4, // 增加padding，因为现在只有3个按钮
-    maxWidth: 100, // 增加最大宽度
-  },
+    actionButton: {
+      flexDirection: 'row', // 图标+文字横排
+      alignItems: 'center',
+      flex: 1, // 平均占用空间
+      justifyContent: 'center', // 居中对齐
+      paddingHorizontal: 4, // 增加padding，因为现在只有3个按钮
+      maxWidth: 100, // 增加最大宽度
+    },
 
-  actionText: {
-    fontSize: 11, // 稍微减小字体以适应更多按钮
-    color: Colors.textSecondary,
-    marginLeft: 6, // 减少左边距
-    flexShrink: 1, // 允许文字压缩
-  },
+    actionText: {
+      fontSize: 11, // 稍微减小字体以适应更多按钮
+      color: colors.textSecondary,
+      marginLeft: 6, // 减少左边距
+      flexShrink: 1, // 允许文字压缩
+    },
 
-  fab: {
-    position: 'absolute',
-    right: Spacing.screenPadding,
-    bottom: Spacing.xl,
-  },
+    fab: {
+      position: 'absolute',
+      right: Spacing.screenPadding,
+      bottom: Spacing.xl,
+    },
 
-  emptyImage: {
-    width: 200,
-    height: 150,
-  },
+    emptyImage: {
+      width: 200,
+      height: 150,
+    },
 
-  headerButton: {
-    marginLeft: Spacing.md,
-  },
-})
+    headerButton: {
+      marginLeft: Spacing.md,
+    },
+  })

--- a/app/(app)/select-emoji/[listId]/[itemId].tsx
+++ b/app/(app)/select-emoji/[listId]/[itemId].tsx
@@ -12,10 +12,11 @@ import {
 } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 
-import { Colors } from '@/constants/Colors'
+import { type ThemeColors } from '@/constants/Colors'
 import { Spacing } from '@/constants/Layout'
 import { Typography } from '@/constants/Typography'
 import { useApp } from '@/context/AppContext'
+import { useThemeColors } from '@/hooks/useThemeColors'
 import { HapticFeedback } from '@/utils/haptics'
 
 const EMOJI_DATA = [
@@ -112,6 +113,8 @@ export default function SelectEmojiScreen() {
   const item = list?.items.find(i => i.id === itemIdStr)
 
   const [customInput, setCustomInput] = useState('')
+  const colors = useThemeColors()
+  const styles = React.useMemo(() => createStyles(colors), [colors])
 
   // 处理自定义输入的逻辑
   const processCustomInput = (input: string): string => {
@@ -183,8 +186,8 @@ export default function SelectEmojiScreen() {
       <Stack.Screen
         options={{
           title: 'Choose Emoji',
-          headerStyle: { backgroundColor: Colors.background },
-          headerTintColor: Colors.text,
+          headerStyle: { backgroundColor: colors.background },
+          headerTintColor: colors.text,
           headerTitleStyle: { fontSize: 18, fontWeight: '600' },
         }}
       />
@@ -203,7 +206,7 @@ export default function SelectEmojiScreen() {
                 value={customInput}
                 onChangeText={setCustomInput}
                 placeholder="Enter emoji or text..."
-                placeholderTextColor={Colors.textTertiary}
+                placeholderTextColor={colors.textTertiary}
                 maxLength={10}
                 returnKeyType="done"
                 onSubmitEditing={handleCustomSubmit}
@@ -221,7 +224,7 @@ export default function SelectEmojiScreen() {
                   name="checkmark"
                   size={20}
                   color={
-                    customInput.trim() ? Colors.primary : Colors.textTertiary
+                    customInput.trim() ? colors.primary : colors.textTertiary
                   }
                 />
               </TouchableOpacity>
@@ -254,7 +257,7 @@ export default function SelectEmojiScreen() {
                 onPress={handleRemoveEmoji}
                 activeOpacity={0.7}
               >
-                <Ionicons name="trash-outline" size={20} color={Colors.error} />
+                <Ionicons name="trash-outline" size={20} color={colors.error} />
                 <Text style={styles.removeText}>Remove emoji</Text>
               </TouchableOpacity>
             )}
@@ -265,140 +268,141 @@ export default function SelectEmojiScreen() {
   )
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: Colors.background,
-  },
+const createStyles = (colors: ThemeColors) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: colors.background,
+    },
 
-  content: {
-    flex: 1,
-    padding: 24,
-  },
+    content: {
+      flex: 1,
+      padding: 24,
+    },
 
-  subtitle: {
-    fontSize: 17,
-    color: Colors.textSecondary,
-    textAlign: 'center',
-    marginBottom: 24,
-    lineHeight: 24,
-  },
+    subtitle: {
+      fontSize: 17,
+      color: colors.textSecondary,
+      textAlign: 'center',
+      marginBottom: 24,
+      lineHeight: 24,
+    },
 
-  customInputSection: {
-    marginBottom: 32,
-    backgroundColor: Colors.surface,
-    borderRadius: 16,
-    padding: 20,
-  },
+    customInputSection: {
+      marginBottom: 32,
+      backgroundColor: colors.surface,
+      borderRadius: 16,
+      padding: 20,
+    },
 
-  inputLabel: {
-    fontSize: 16,
-    fontWeight: Typography.fontWeight.medium,
-    color: Colors.text,
-    marginBottom: 12,
-  },
+    inputLabel: {
+      fontSize: 16,
+      fontWeight: Typography.fontWeight.medium,
+      color: colors.text,
+      marginBottom: 12,
+    },
 
-  inputContainer: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: Colors.background,
-    borderRadius: 12,
-    paddingHorizontal: 16,
-    paddingVertical: 4,
-  },
+    inputContainer: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      backgroundColor: colors.background,
+      borderRadius: 12,
+      paddingHorizontal: 16,
+      paddingVertical: 4,
+    },
 
-  textInput: {
-    flex: 1,
-    fontSize: 16,
-    color: Colors.text,
-    paddingVertical: 12,
-  },
+    textInput: {
+      flex: 1,
+      fontSize: 16,
+      color: colors.text,
+      paddingVertical: 12,
+    },
 
-  submitButton: {
-    width: 36,
-    height: 36,
-    borderRadius: 18,
-    backgroundColor: Colors.primary + '20',
-    justifyContent: 'center',
-    alignItems: 'center',
-    marginLeft: 8,
-  },
+    submitButton: {
+      width: 36,
+      height: 36,
+      borderRadius: 18,
+      backgroundColor: colors.primary + '20',
+      justifyContent: 'center',
+      alignItems: 'center',
+      marginLeft: 8,
+    },
 
-  submitButtonDisabled: {
-    backgroundColor: Colors.surface,
-  },
+    submitButtonDisabled: {
+      backgroundColor: colors.surface,
+    },
 
-  preview: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginTop: 12,
-    paddingTop: 12,
-    borderTopWidth: 1,
-    borderTopColor: Colors.background,
-  },
+    preview: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      marginTop: 12,
+      paddingTop: 12,
+      borderTopWidth: 1,
+      borderTopColor: colors.background,
+    },
 
-  previewLabel: {
-    fontSize: 14,
-    color: Colors.textSecondary,
-    marginRight: 12,
-  },
+    previewLabel: {
+      fontSize: 14,
+      color: colors.textSecondary,
+      marginRight: 12,
+    },
 
-  previewEmoji: {
-    width: 32,
-    height: 32,
-    borderRadius: 8,
-    backgroundColor: Colors.background,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
+    previewEmoji: {
+      width: 32,
+      height: 32,
+      borderRadius: 8,
+      backgroundColor: colors.background,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
 
-  previewText: {
-    fontSize: 18,
-  },
+    previewText: {
+      fontSize: 18,
+    },
 
-  emojiGrid: {
-    paddingBottom: 20,
-  },
+    emojiGrid: {
+      paddingBottom: 20,
+    },
 
-  emojiButton: {
-    width: 48,
-    height: 48,
-    margin: 8,
-    borderRadius: 12,
-    backgroundColor: Colors.surface,
-    justifyContent: 'center',
-    alignItems: 'center',
-    borderWidth: 2,
-    borderColor: 'transparent',
-  },
+    emojiButton: {
+      width: 48,
+      height: 48,
+      margin: 8,
+      borderRadius: 12,
+      backgroundColor: colors.surface,
+      justifyContent: 'center',
+      alignItems: 'center',
+      borderWidth: 2,
+      borderColor: 'transparent',
+    },
 
-  selectedEmoji: {
-    borderColor: Colors.primary,
-    backgroundColor: Colors.primary + '20',
-  },
+    selectedEmoji: {
+      borderColor: colors.primary,
+      backgroundColor: colors.primary + '20',
+    },
 
-  emojiText: {
-    fontSize: 24,
-  },
+    emojiText: {
+      fontSize: 24,
+    },
 
-  actions: {
-    paddingTop: 20,
-    alignItems: 'center',
-  },
+    actions: {
+      paddingTop: 20,
+      alignItems: 'center',
+    },
 
-  removeButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingVertical: 12,
-    paddingHorizontal: 20,
-    borderRadius: 20,
-    backgroundColor: Colors.surface,
-  },
+    removeButton: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingVertical: 12,
+      paddingHorizontal: 20,
+      borderRadius: 20,
+      backgroundColor: colors.surface,
+    },
 
-  removeText: {
-    fontSize: 16,
-    color: Colors.error,
-    marginLeft: 8,
-    fontWeight: Typography.fontWeight.medium,
-  },
-})
+    removeText: {
+      fontSize: 16,
+      color: colors.error,
+      marginLeft: 8,
+      fontWeight: Typography.fontWeight.medium,
+    },
+  })

--- a/app/(app)/settings.tsx
+++ b/app/(app)/settings.tsx
@@ -1,6 +1,6 @@
 import { Ionicons } from '@expo/vector-icons'
 import { useRouter } from 'expo-router'
-import React from 'react'
+import React, { useMemo } from 'react'
 import {
   View,
   Text,
@@ -11,9 +11,11 @@ import {
 } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 
-import { Colors } from '@/constants/Colors'
+import { Colors, ThemeColors } from '@/constants/Colors'
 import { Spacing, BorderRadius, Shadows } from '@/constants/Layout'
 import { Typography } from '@/constants/Typography'
+import { useTheme } from '@/context/ThemeContext'
+import { useColorScheme } from '@/hooks/useColorScheme'
 import { HapticFeedback } from '@/utils/haptics'
 
 interface SettingsItemProps {
@@ -26,38 +28,166 @@ interface SettingsItemProps {
   rightText?: string
 }
 
-const SettingsItem: React.FC<SettingsItemProps> = ({
-  title,
-  subtitle,
-  icon,
-  iconColor = Colors.textSecondary,
-  onPress,
-  isLast = false,
-  rightText,
-}) => (
-  <TouchableOpacity
-    style={[styles.settingsItem, isLast && styles.lastSettingsItem]}
-    onPress={onPress}
-    activeOpacity={0.7}
-  >
-    <View style={styles.settingsItemLeft}>
-      <View style={styles.iconContainer}>
-        <Ionicons name={icon as any} size={22} color={iconColor} />
-      </View>
-      <View style={styles.textContainer}>
-        <Text style={styles.settingsTitle}>{title}</Text>
-        {subtitle && <Text style={styles.settingsSubtitle}>{subtitle}</Text>}
-      </View>
-    </View>
-    <View style={styles.settingsItemRight}>
-      {rightText && <Text style={styles.rightText}>{rightText}</Text>}
-      <Ionicons name="chevron-forward" size={18} color={Colors.textTertiary} />
-    </View>
-  </TouchableOpacity>
-)
+const createStyles = (colors: ThemeColors) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: colors.background,
+    },
+
+    header: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      height: 56,
+      paddingHorizontal: 24,
+      backgroundColor: colors.background,
+    },
+
+    backButton: {
+      width: 44,
+      height: 44,
+      alignItems: 'center',
+      justifyContent: 'center',
+      marginLeft: -12,
+    },
+
+    headerTitle: {
+      fontSize: 24,
+      fontWeight: Typography.fontWeight.semibold,
+      color: colors.text,
+      flex: 1,
+      marginLeft: 12,
+    },
+
+    headerRight: {
+      width: 44,
+    },
+
+    content: {
+      flex: 1,
+    },
+
+    section: {
+      marginBottom: Spacing.xl,
+    },
+
+    sectionTitle: {
+      fontSize: 13,
+      fontWeight: Typography.fontWeight.semibold,
+      color: colors.textSecondary,
+      textTransform: 'uppercase',
+      letterSpacing: 0.5,
+      marginHorizontal: Spacing.screenPadding,
+      marginBottom: Spacing.md,
+      marginTop: Spacing.lg,
+    },
+
+    cardContainer: {
+      backgroundColor: colors.surface,
+      marginHorizontal: Spacing.screenPadding,
+      borderRadius: BorderRadius.lg,
+      overflow: 'hidden',
+      ...Shadows.small,
+    },
+
+    settingsItem: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingHorizontal: Spacing.md,
+      paddingVertical: Spacing.lg,
+      borderBottomWidth: 0.5,
+      borderBottomColor: colors.border,
+    },
+
+    lastSettingsItem: {
+      borderBottomWidth: 0,
+    },
+
+    settingsItemLeft: {
+      flex: 1,
+      flexDirection: 'row',
+      alignItems: 'center',
+    },
+
+    settingsItemRight: {
+      flexDirection: 'row',
+      alignItems: 'center',
+    },
+
+    iconContainer: {
+      width: 40,
+      height: 40,
+      borderRadius: 10,
+      backgroundColor: colors.surfaceElevated,
+      alignItems: 'center',
+      justifyContent: 'center',
+      marginRight: Spacing.md,
+    },
+
+    textContainer: {
+      flex: 1,
+    },
+
+    settingsTitle: {
+      fontSize: 16,
+      fontWeight: Typography.fontWeight.medium,
+      color: colors.text,
+      marginBottom: 2,
+    },
+
+    settingsSubtitle: {
+      fontSize: 14,
+      color: colors.textSecondary,
+      lineHeight: 18,
+    },
+
+    rightText: {
+      fontSize: 15,
+      color: colors.textSecondary,
+      marginRight: Spacing.sm,
+    },
+  })
 
 export default function SettingsScreen() {
   const router = useRouter()
+  const { themePreference, setThemePreference } = useTheme()
+  const colorScheme = useColorScheme()
+  const colors = Colors[colorScheme]
+  const styles = useMemo(() => createStyles(colors), [colors])
+
+  const SettingsItem = ({
+    title,
+    subtitle,
+    icon,
+    iconColor = colors.textSecondary,
+    onPress,
+    isLast = false,
+    rightText,
+  }: SettingsItemProps) => (
+    <TouchableOpacity
+      style={[styles.settingsItem, isLast && styles.lastSettingsItem]}
+      onPress={onPress}
+      activeOpacity={0.7}
+    >
+      <View style={styles.settingsItemLeft}>
+        <View style={styles.iconContainer}>
+          <Ionicons name={icon as any} size={22} color={iconColor} />
+        </View>
+        <View style={styles.textContainer}>
+          <Text style={styles.settingsTitle}>{title}</Text>
+          {subtitle && <Text style={styles.settingsSubtitle}>{subtitle}</Text>}
+        </View>
+      </View>
+      <View style={styles.settingsItemRight}>
+        {rightText && <Text style={styles.rightText}>{rightText}</Text>}
+        <Ionicons
+          name="chevron-forward"
+          size={18}
+          color={colors.textTertiary}
+        />
+      </View>
+    </TouchableOpacity>
+  )
 
   const handleBack = () => {
     HapticFeedback.light()
@@ -74,11 +204,28 @@ export default function SettingsScreen() {
     router.push('/(app)/trash')
   }
 
+  const handleTheme = () => {
+    HapticFeedback.light()
+    Alert.alert('Theme', 'Select app theme', [
+      { text: 'Light', onPress: () => setThemePreference('light') },
+      { text: 'Dark', onPress: () => setThemePreference('dark') },
+      { text: 'System', onPress: () => setThemePreference('system') },
+      { text: 'Cancel', style: 'cancel' },
+    ])
+  }
+
+  const themeLabel =
+    themePreference === 'system'
+      ? 'System'
+      : themePreference === 'light'
+        ? 'Light'
+        : 'Dark'
+
   return (
     <SafeAreaView style={styles.container}>
       <View style={styles.header}>
         <TouchableOpacity onPress={handleBack} style={styles.backButton}>
-          <Ionicons name="chevron-back" size={24} color={Colors.text} />
+          <Ionicons name="chevron-back" size={24} color={colors.text} />
         </TouchableOpacity>
 
         <Text style={styles.headerTitle}>Settings</Text>
@@ -87,6 +234,21 @@ export default function SettingsScreen() {
       </View>
 
       <ScrollView style={styles.content} showsVerticalScrollIndicator={false}>
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Appearance</Text>
+
+          <View style={styles.cardContainer}>
+            <SettingsItem
+              title="Theme"
+              subtitle="Light or dark mode"
+              icon="color-palette-outline"
+              onPress={handleTheme}
+              rightText={themeLabel}
+              isLast={true}
+            />
+          </View>
+        </View>
+
         <View style={styles.section}>
           <Text style={styles.sectionTitle}>Lists</Text>
 
@@ -132,122 +294,3 @@ export default function SettingsScreen() {
     </SafeAreaView>
   )
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: Colors.background,
-  },
-
-  header: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    height: 56,
-    paddingHorizontal: 24,
-    backgroundColor: Colors.background,
-  },
-
-  backButton: {
-    width: 44,
-    height: 44,
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginLeft: -12,
-  },
-
-  headerTitle: {
-    fontSize: 24,
-    fontWeight: Typography.fontWeight.semibold,
-    color: Colors.text,
-    flex: 1,
-    marginLeft: 12,
-  },
-
-  headerRight: {
-    width: 44,
-  },
-
-  content: {
-    flex: 1,
-  },
-
-  section: {
-    marginBottom: Spacing.xl,
-  },
-
-  sectionTitle: {
-    fontSize: 13,
-    fontWeight: Typography.fontWeight.semibold,
-    color: Colors.textSecondary,
-    textTransform: 'uppercase',
-    letterSpacing: 0.5,
-    marginHorizontal: Spacing.screenPadding,
-    marginBottom: Spacing.md,
-    marginTop: Spacing.lg,
-  },
-
-  cardContainer: {
-    backgroundColor: Colors.surface,
-    marginHorizontal: Spacing.screenPadding,
-    borderRadius: BorderRadius.lg,
-    overflow: 'hidden',
-    ...Shadows.small,
-  },
-
-  settingsItem: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingHorizontal: Spacing.md,
-    paddingVertical: Spacing.lg,
-    borderBottomWidth: 0.5,
-    borderBottomColor: Colors.border,
-  },
-
-  lastSettingsItem: {
-    borderBottomWidth: 0,
-  },
-
-  settingsItemLeft: {
-    flex: 1,
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-
-  settingsItemRight: {
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-
-  iconContainer: {
-    width: 40,
-    height: 40,
-    borderRadius: 10,
-    backgroundColor: Colors.surfaceElevated,
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginRight: Spacing.md,
-  },
-
-  textContainer: {
-    flex: 1,
-  },
-
-  settingsTitle: {
-    fontSize: 16,
-    fontWeight: Typography.fontWeight.medium,
-    color: Colors.text,
-    marginBottom: 2,
-  },
-
-  settingsSubtitle: {
-    fontSize: 14,
-    color: Colors.textSecondary,
-    lineHeight: 18,
-  },
-
-  rightText: {
-    fontSize: 15,
-    color: Colors.textSecondary,
-    marginRight: Spacing.sm,
-  },
-})

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -14,7 +14,7 @@ export default function TabLayout() {
   return (
     <Tabs
       screenOptions={{
-        tabBarActiveTintColor: Colors[colorScheme ?? 'light'].tint,
+        tabBarActiveTintColor: Colors[colorScheme].tint,
         headerShown: false,
         tabBarButton: HapticTab,
         tabBarBackground: TabBarBackground,

--- a/app/(tabs)/explore.tsx
+++ b/app/(tabs)/explore.tsx
@@ -7,15 +7,19 @@ import ParallaxScrollView from '@/components/ParallaxScrollView'
 import { ThemedText } from '@/components/ThemedText'
 import { ThemedView } from '@/components/ThemedView'
 import { IconSymbol } from '@/components/ui/IconSymbol'
+import { Colors } from '@/constants/Colors'
 
 export default function TabTwoScreen() {
   return (
     <ParallaxScrollView
-      headerBackgroundColor={{ light: '#D0D0D0', dark: '#353636' }}
+      headerBackgroundColor={{
+        light: Colors.light.background,
+        dark: Colors.dark.background,
+      }}
       headerImage={
         <IconSymbol
           size={310}
-          color="#808080"
+          color={Colors.textSecondary}
           name="chevron.left.forwardslash.chevron.right"
           style={styles.headerImage}
         />
@@ -118,7 +122,6 @@ export default function TabTwoScreen() {
 
 const styles = StyleSheet.create({
   headerImage: {
-    color: '#808080',
     bottom: -90,
     left: -35,
     position: 'absolute',

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -5,11 +5,15 @@ import { HelloWave } from '@/components/HelloWave'
 import ParallaxScrollView from '@/components/ParallaxScrollView'
 import { ThemedText } from '@/components/ThemedText'
 import { ThemedView } from '@/components/ThemedView'
+import { Colors } from '@/constants/Colors'
 
 export default function HomeScreen() {
   return (
     <ParallaxScrollView
-      headerBackgroundColor={{ light: '#A1CEDC', dark: '#1D3D47' }}
+      headerBackgroundColor={{
+        light: Colors.light.background,
+        dark: Colors.dark.background,
+      }}
       headerImage={
         <Image
           source={require('@/assets/images/partial-react-logo.png')}

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -18,12 +18,12 @@ const customDarkTheme = {
   ...DarkTheme,
   colors: {
     ...DarkTheme.colors,
-    background: Colors.dark.background,
-    card: Colors.dark.surface,
-    text: Colors.dark.text,
-    border: Colors.dark.border,
-    notification: Colors.dark.primary,
-    primary: Colors.dark.primary,
+    background: Colors.dark?.background ?? Colors.background,
+    card: Colors.dark?.surface ?? Colors.surface,
+    text: Colors.dark?.text ?? Colors.text,
+    border: Colors.dark?.border ?? Colors.border,
+    notification: Colors.dark?.primary ?? Colors.primary,
+    primary: Colors.dark?.primary ?? Colors.primary,
   },
 }
 
@@ -31,12 +31,12 @@ const customLightTheme = {
   ...DefaultTheme,
   colors: {
     ...DefaultTheme.colors,
-    background: Colors.light.background,
-    card: Colors.light.surface,
-    text: Colors.light.text,
-    border: Colors.light.border,
-    notification: Colors.light.primary,
-    primary: Colors.light.primary,
+    background: Colors.light?.background ?? Colors.background,
+    card: Colors.light?.surface ?? Colors.surface,
+    text: Colors.light?.text ?? Colors.text,
+    border: Colors.light?.border ?? Colors.border,
+    notification: Colors.light?.primary ?? Colors.primary,
+    primary: Colors.light?.primary ?? Colors.primary,
   },
 }
 

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,7 +1,7 @@
 import {
   DarkTheme,
   DefaultTheme,
-  ThemeProvider,
+  ThemeProvider as NavigationThemeProvider,
 } from '@react-navigation/native'
 import { useFonts } from 'expo-font'
 import { Stack } from 'expo-router'
@@ -11,23 +11,55 @@ import 'react-native-reanimated'
 
 import { Colors } from '@/constants/Colors'
 import { AppProvider } from '@/context/AppContext'
+import { ThemeProvider as ThemePreferenceProvider } from '@/context/ThemeContext'
 import { useColorScheme } from '@/hooks/useColorScheme'
 
 const customDarkTheme = {
   ...DarkTheme,
   colors: {
     ...DarkTheme.colors,
-    background: Colors.background,
-    card: Colors.surface,
-    text: Colors.text,
-    border: Colors.border,
-    notification: Colors.primary,
-    primary: Colors.primary,
+    background: Colors.dark.background,
+    card: Colors.dark.surface,
+    text: Colors.dark.text,
+    border: Colors.dark.border,
+    notification: Colors.dark.primary,
+    primary: Colors.dark.primary,
   },
 }
 
-export default function RootLayout() {
+const customLightTheme = {
+  ...DefaultTheme,
+  colors: {
+    ...DefaultTheme.colors,
+    background: Colors.light.background,
+    card: Colors.light.surface,
+    text: Colors.light.text,
+    border: Colors.light.border,
+    notification: Colors.light.primary,
+    primary: Colors.light.primary,
+  },
+}
+
+function AppInner() {
   const colorScheme = useColorScheme()
+  const theme = colorScheme === 'dark' ? customDarkTheme : customLightTheme
+  return (
+    <NavigationThemeProvider value={theme}>
+      <Stack screenOptions={{ headerShown: false }}>
+        <Stack.Screen name="index" />
+        <Stack.Screen name="(onboarding)" />
+        <Stack.Screen name="(app)" />
+        <Stack.Screen name="+not-found" />
+      </Stack>
+      <StatusBar
+        style={colorScheme === 'dark' ? 'light' : 'dark'}
+        backgroundColor={Colors[colorScheme].background}
+      />
+    </NavigationThemeProvider>
+  )
+}
+
+export default function RootLayout() {
   const [loaded] = useFonts({
     SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
   })
@@ -38,17 +70,11 @@ export default function RootLayout() {
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
-      <AppProvider>
-        <ThemeProvider value={customDarkTheme}>
-          <Stack screenOptions={{ headerShown: false }}>
-            <Stack.Screen name="index" />
-            <Stack.Screen name="(onboarding)" />
-            <Stack.Screen name="(app)" />
-            <Stack.Screen name="+not-found" />
-          </Stack>
-          <StatusBar style="light" backgroundColor={Colors.background} />
-        </ThemeProvider>
-      </AppProvider>
+      <ThemePreferenceProvider>
+        <AppProvider>
+          <AppInner />
+        </AppProvider>
+      </ThemePreferenceProvider>
     </GestureHandlerRootView>
   )
 }

--- a/components/ThemedText.tsx
+++ b/components/ThemedText.tsx
@@ -1,5 +1,6 @@
 import { StyleSheet, Text, type TextProps } from 'react-native'
 
+import { Colors } from '@/constants/Colors'
 import { useThemeColor } from '@/hooks/useThemeColor'
 
 export type ThemedTextProps = TextProps & {
@@ -55,6 +56,6 @@ const styles = StyleSheet.create({
   link: {
     lineHeight: 30,
     fontSize: 16,
-    color: '#0a7ea4',
+    color: Colors.tint,
   },
 })

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -8,9 +8,10 @@ import {
   TextStyle,
 } from 'react-native'
 
-import { Colors } from '@/constants/Colors'
+import { type ThemeColors } from '@/constants/Colors'
 import { Spacing, BorderRadius, Shadows } from '@/constants/Layout'
 import { Typography } from '@/constants/Typography'
+import { useThemeColors } from '@/hooks/useThemeColors'
 import { HapticFeedback } from '@/utils/haptics'
 
 interface ButtonProps {
@@ -36,6 +37,9 @@ export const Button: React.FC<ButtonProps> = ({
   textStyle,
   fullWidth = false,
 }) => {
+  const colors = useThemeColors()
+  const styles = React.useMemo(() => createStyles(colors), [colors])
+
   const buttonStyles = [
     styles.base,
     styles[variant],
@@ -70,7 +74,7 @@ export const Button: React.FC<ButtonProps> = ({
       {loading ? (
         <ActivityIndicator
           size="small"
-          color={variant === 'primary' ? Colors.text : Colors.primary}
+          color={variant === 'primary' ? colors.text : colors.primary}
         />
       ) : (
         <Text style={textStyles}>{title}</Text>
@@ -79,71 +83,72 @@ export const Button: React.FC<ButtonProps> = ({
   )
 }
 
-const styles = StyleSheet.create({
-  base: {
-    alignItems: 'center',
-    justifyContent: 'center',
-    borderRadius: BorderRadius.pill,
-    ...Shadows.small,
-  },
+const createStyles = (colors: ThemeColors) =>
+  StyleSheet.create({
+    base: {
+      alignItems: 'center',
+      justifyContent: 'center',
+      borderRadius: BorderRadius.pill,
+      ...Shadows.small,
+    },
 
-  // Variants
-  primary: {
-    backgroundColor: Colors.primary,
-  },
-  secondary: {
-    backgroundColor: Colors.surface,
-    borderWidth: 1,
-    borderColor: Colors.border,
-  },
+    // Variants
+    primary: {
+      backgroundColor: colors.primary,
+    },
+    secondary: {
+      backgroundColor: colors.surface,
+      borderWidth: 1,
+      borderColor: colors.border,
+    },
 
-  // Sizes
-  small: {
-    height: 36,
-    paddingHorizontal: Spacing.md,
-  },
-  medium: {
-    height: 44,
-    paddingHorizontal: Spacing.lg,
-  },
-  large: {
-    height: Spacing.buttonHeight,
-    paddingHorizontal: Spacing.lg,
-  },
+    // Sizes
+    small: {
+      height: 36,
+      paddingHorizontal: Spacing.md,
+    },
+    medium: {
+      height: 44,
+      paddingHorizontal: Spacing.lg,
+    },
+    large: {
+      height: Spacing.buttonHeight,
+      paddingHorizontal: Spacing.lg,
+    },
 
-  // Full width
-  fullWidth: {
-    width: '100%',
-  },
+    // Full width
+    fullWidth: {
+      width: '100%',
+    },
 
-  // States
-  disabled: {
-    opacity: 0.5,
-  },
+    // States
+    disabled: {
+      opacity: 0.5,
+    },
 
-  // Text styles
-  text: {
-    ...Typography.textStyles.buttonLabel,
-    textAlign: 'center',
-  },
-  primaryText: {
-    color: Colors.text,
-  },
-  secondaryText: {
-    color: Colors.textSecondary,
-  },
+    // Text styles
+    text: {
+      ...Typography.textStyles.buttonLabel,
+      textAlign: 'center',
+    },
+    primaryText: {
+      color: colors.text,
+    },
+    secondaryText: {
+      color: colors.textSecondary,
+    },
 
-  smallText: {
-    fontSize: 14,
-  },
-  mediumText: {
-    fontSize: 15,
-  },
-  largeText: {
-    fontSize: 16,
-  },
+    smallText: {
+      fontSize: 14,
+    },
+    mediumText: {
+      fontSize: 15,
+    },
+    largeText: {
+      fontSize: 16,
+    },
 
-  disabledText: {
-    color: Colors.textTertiary,
-  },
-})
+    disabledText: {
+      color: colors.textTertiary,
+    },
+  })

--- a/components/ui/Checkbox.tsx
+++ b/components/ui/Checkbox.tsx
@@ -2,7 +2,7 @@ import { Ionicons } from '@expo/vector-icons'
 import React from 'react'
 import { TouchableOpacity, StyleSheet, ViewStyle } from 'react-native'
 
-import { Colors } from '@/constants/Colors'
+import { useThemeColors } from '@/hooks/useThemeColors'
 import { HapticFeedback } from '@/utils/haptics'
 
 interface CheckboxProps {
@@ -18,6 +18,7 @@ export const Checkbox: React.FC<CheckboxProps> = ({
   size = 26, // 稍微增大默认尺寸
   style,
 }) => {
+  const colors = useThemeColors()
   const handleToggle = () => {
     if (checked) {
       HapticFeedback.light()
@@ -35,19 +36,15 @@ export const Checkbox: React.FC<CheckboxProps> = ({
           width: size,
           height: size,
           borderRadius: size / 2,
+          borderColor: checked ? colors.success : colors.textSecondary,
         },
-        checked ? styles.checked : styles.unchecked,
         style,
       ]}
       onPress={handleToggle}
       activeOpacity={0.7}
     >
       {checked && (
-        <Ionicons
-          name="checkmark"
-          size={size * 0.5}
-          color="#2ECC71" // Figma规格的绿色
-        />
+        <Ionicons name="checkmark" size={size * 0.5} color={colors.success} />
       )}
     </TouchableOpacity>
   )
@@ -58,15 +55,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     borderWidth: 3, // 3pt线宽
-  },
-
-  unchecked: {
     backgroundColor: 'transparent',
-    borderColor: '#585858', // Figma规格：灰线 #585858
-  },
-
-  checked: {
-    backgroundColor: 'transparent', // 保持透明，只显示绿色勾选
-    borderColor: '#2ECC71', // 绿色边框
   },
 })

--- a/components/ui/DetailHeader.tsx
+++ b/components/ui/DetailHeader.tsx
@@ -3,9 +3,10 @@ import React from 'react'
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
-import { Colors } from '@/constants/Colors'
+import { type ThemeColors } from '@/constants/Colors'
 import { Spacing } from '@/constants/Layout'
 import { Typography } from '@/constants/Typography'
+import { useThemeColors } from '@/hooks/useThemeColors'
 
 import { ProgressChip } from './ProgressChip'
 
@@ -25,12 +26,14 @@ export const DetailHeader: React.FC<DetailHeaderProps> = ({
   onMenuPress,
 }) => {
   const insets = useSafeAreaInsets()
+  const colors = useThemeColors()
+  const styles = React.useMemo(() => createStyles(colors), [colors])
 
   return (
     <View style={[styles.container, { paddingTop: insets.top }]}>
       <View style={styles.content}>
         <TouchableOpacity onPress={onBackPress} style={styles.backButton}>
-          <Ionicons name="chevron-back" size={24} color={Colors.text} />
+          <Ionicons name="chevron-back" size={24} color={colors.text} />
         </TouchableOpacity>
 
         <Text style={styles.title} numberOfLines={1}>
@@ -41,7 +44,7 @@ export const DetailHeader: React.FC<DetailHeaderProps> = ({
           <ProgressChip
             completed={completed}
             total={total}
-            size={44} // 44x44 Figma规格
+            size={44}
             variant="small"
           />
           {onMenuPress && (
@@ -49,7 +52,7 @@ export const DetailHeader: React.FC<DetailHeaderProps> = ({
               <Ionicons
                 name="ellipsis-horizontal"
                 size={24}
-                color={Colors.text}
+                color={colors.text}
               />
             </TouchableOpacity>
           )}
@@ -59,45 +62,46 @@ export const DetailHeader: React.FC<DetailHeaderProps> = ({
   )
 }
 
-const styles = StyleSheet.create({
-  container: {
-    backgroundColor: Colors.background,
-  },
+const createStyles = (colors: ThemeColors) =>
+  StyleSheet.create({
+    container: {
+      backgroundColor: colors.background,
+    },
 
-  content: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    height: 56, // 增加高度让标题更舒适
-    paddingHorizontal: 24, // 24pt左右内边距
-  },
+    content: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      height: 56, // 增加高度让标题更舒适
+      paddingHorizontal: 24, // 24pt左右内边距
+    },
 
-  backButton: {
-    width: 44,
-    height: 44,
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginLeft: -12, // 调整视觉平衡
-  },
+    backButton: {
+      width: 44,
+      height: 44,
+      alignItems: 'center',
+      justifyContent: 'center',
+      marginLeft: -12, // 调整视觉平衡
+    },
 
-  title: {
-    fontSize: 24, // 24-26pt标题字号
-    fontWeight: Typography.fontWeight.semibold, // Semibold
-    color: Colors.text,
-    flex: 1,
-    marginLeft: 12, // 标题与圆环间距12-16pt
-    marginRight: 16,
-  },
+    title: {
+      fontSize: 24, // 24-26pt标题字号
+      fontWeight: Typography.fontWeight.semibold, // Semibold
+      color: colors.text,
+      flex: 1,
+      marginLeft: 12, // 标题与圆环间距12-16pt
+      marginRight: 16,
+    },
 
-  rightSection: {
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
+    rightSection: {
+      flexDirection: 'row',
+      alignItems: 'center',
+    },
 
-  menuButton: {
-    width: 44,
-    height: 44,
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginLeft: 8,
-  },
-})
+    menuButton: {
+      width: 44,
+      height: 44,
+      alignItems: 'center',
+      justifyContent: 'center',
+      marginLeft: 8,
+    },
+  })

--- a/components/ui/EmptyState.tsx
+++ b/components/ui/EmptyState.tsx
@@ -1,9 +1,10 @@
 import React from 'react'
 import { View, Text, StyleSheet, ViewStyle } from 'react-native'
 
-import { Colors } from '@/constants/Colors'
+import { type ThemeColors } from '@/constants/Colors'
 import { Spacing } from '@/constants/Layout'
 import { Typography } from '@/constants/Typography'
+import { useThemeColors } from '@/hooks/useThemeColors'
 
 interface EmptyStateProps {
   title: string
@@ -22,6 +23,9 @@ export const EmptyState: React.FC<EmptyStateProps> = ({
   action,
   style,
 }) => {
+  const colors = useThemeColors()
+  const styles = React.useMemo(() => createStyles(colors), [colors])
+
   return (
     <View style={[styles.container, style]}>
       {(icon || illustration) && (
@@ -38,39 +42,40 @@ export const EmptyState: React.FC<EmptyStateProps> = ({
   )
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingHorizontal: Spacing.screenPadding,
-  },
+const createStyles = (colors: ThemeColors) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'center',
+      paddingHorizontal: Spacing.screenPadding,
+    },
 
-  iconContainer: {
-    marginBottom: Spacing.xl,
-    alignItems: 'center',
-  },
+    iconContainer: {
+      marginBottom: Spacing.xl,
+      alignItems: 'center',
+    },
 
-  textContainer: {
-    alignItems: 'center',
-    marginBottom: Spacing.xl,
-  },
+    textContainer: {
+      alignItems: 'center',
+      marginBottom: Spacing.xl,
+    },
 
-  title: {
-    ...Typography.textStyles.title,
-    color: Colors.text,
-    textAlign: 'center',
-    marginBottom: Spacing.sm,
-  },
+    title: {
+      ...Typography.textStyles.title,
+      color: colors.text,
+      textAlign: 'center',
+      marginBottom: Spacing.sm,
+    },
 
-  subtitle: {
-    ...Typography.textStyles.body,
-    color: Colors.textSecondary,
-    textAlign: 'center',
-    lineHeight: 24,
-  },
+    subtitle: {
+      ...Typography.textStyles.body,
+      color: colors.textSecondary,
+      textAlign: 'center',
+      lineHeight: 24,
+    },
 
-  actionContainer: {
-    width: '100%',
-  },
-})
+    actionContainer: {
+      width: '100%',
+    },
+  })

--- a/components/ui/FloatingActionButton.tsx
+++ b/components/ui/FloatingActionButton.tsx
@@ -9,8 +9,9 @@ import Animated, {
   runOnJS,
 } from 'react-native-reanimated'
 
-import { Colors } from '@/constants/Colors'
+import { type ThemeColors } from '@/constants/Colors'
 import { Shadows } from '@/constants/Layout'
+import { useThemeColors } from '@/hooks/useThemeColors'
 
 interface FloatingActionButtonProps {
   onPress: () => void
@@ -23,6 +24,8 @@ export const FloatingActionButton: React.FC<FloatingActionButtonProps> = ({
   icon = 'add',
   size = 56,
 }) => {
+  const colors = useThemeColors()
+  const styles = React.useMemo(() => createStyles(colors), [colors])
   const scale = useSharedValue(1)
   const rotation = useSharedValue(0)
 
@@ -65,17 +68,18 @@ export const FloatingActionButton: React.FC<FloatingActionButtonProps> = ({
           animatedStyle,
         ]}
       >
-        <Ionicons name={icon} size={size * 0.4} color={Colors.text} />
+        <Ionicons name={icon} size={size * 0.4} color={colors.text} />
       </Animated.View>
     </TouchableOpacity>
   )
 }
 
-const styles = StyleSheet.create({
-  container: {
-    backgroundColor: Colors.primary,
-    alignItems: 'center',
-    justifyContent: 'center',
-    ...Shadows.large,
-  },
-})
+const createStyles = (colors: ThemeColors) =>
+  StyleSheet.create({
+    container: {
+      backgroundColor: colors.primary,
+      alignItems: 'center',
+      justifyContent: 'center',
+      ...Shadows.large,
+    },
+  })

--- a/components/ui/Header.tsx
+++ b/components/ui/Header.tsx
@@ -9,9 +9,10 @@ import {
 } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
-import { Colors } from '@/constants/Colors'
+import { type ThemeColors } from '@/constants/Colors'
 import { Spacing } from '@/constants/Layout'
 import { Typography } from '@/constants/Typography'
+import { useThemeColors } from '@/hooks/useThemeColors'
 
 interface HeaderProps {
   title: string
@@ -33,6 +34,8 @@ export const Header: React.FC<HeaderProps> = ({
   style,
 }) => {
   const insets = useSafeAreaInsets()
+  const colors = useThemeColors()
+  const styles = React.useMemo(() => createStyles(colors), [colors])
 
   return (
     <View style={[styles.container, style]}>
@@ -40,7 +43,7 @@ export const Header: React.FC<HeaderProps> = ({
         <View style={styles.leftSection}>
           {showBackButton && onBackPress && (
             <TouchableOpacity onPress={onBackPress} style={styles.backButton}>
-              <Ionicons name="chevron-back" size={24} color={Colors.text} />
+              <Ionicons name="chevron-back" size={24} color={colors.text} />
             </TouchableOpacity>
           )}
           {!showBackButton && leftComponent}
@@ -67,55 +70,56 @@ export const Header: React.FC<HeaderProps> = ({
   )
 }
 
-const styles = StyleSheet.create({
-  container: {
-    backgroundColor: Colors.background,
-  },
+const createStyles = (colors: ThemeColors) =>
+  StyleSheet.create({
+    container: {
+      backgroundColor: colors.background,
+    },
 
-  content: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    height: 44,
-    paddingHorizontal: Spacing.md,
-  },
+    content: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      height: 44,
+      paddingHorizontal: Spacing.md,
+    },
 
-  leftSection: {
-    minWidth: 44,
-    alignItems: 'flex-start',
-    justifyContent: 'center',
-  },
+    leftSection: {
+      minWidth: 44,
+      alignItems: 'flex-start',
+      justifyContent: 'center',
+    },
 
-  centerSection: {
-    flex: 1,
-    alignItems: 'center',
-  },
+    centerSection: {
+      flex: 1,
+      alignItems: 'center',
+    },
 
-  centerSectionLeft: {
-    flex: 1,
-    alignItems: 'flex-start',
-  },
+    centerSectionLeft: {
+      flex: 1,
+      alignItems: 'flex-start',
+    },
 
-  rightSection: {
-    minWidth: 44,
-    alignItems: 'flex-end',
-    justifyContent: 'center',
-  },
+    rightSection: {
+      minWidth: 44,
+      alignItems: 'flex-end',
+      justifyContent: 'center',
+    },
 
-  backButton: {
-    width: 44,
-    height: 44,
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginLeft: -Spacing.sm, // Adjust for visual balance
-  },
+    backButton: {
+      width: 44,
+      height: 44,
+      alignItems: 'center',
+      justifyContent: 'center',
+      marginLeft: -Spacing.sm, // Adjust for visual balance
+    },
 
-  title: {
-    ...Typography.textStyles.title,
-    color: Colors.text,
-    textAlign: 'center',
-  },
+    title: {
+      ...Typography.textStyles.title,
+      color: colors.text,
+      textAlign: 'center',
+    },
 
-  titleLeft: {
-    textAlign: 'left',
-  },
-})
+    titleLeft: {
+      textAlign: 'left',
+    },
+  })

--- a/components/ui/Input.tsx
+++ b/components/ui/Input.tsx
@@ -8,9 +8,10 @@ import {
   ViewStyle,
 } from 'react-native'
 
-import { Colors } from '@/constants/Colors'
+import { type ThemeColors } from '@/constants/Colors'
 import { Spacing, BorderRadius } from '@/constants/Layout'
 import { Typography } from '@/constants/Typography'
+import { useThemeColors } from '@/hooks/useThemeColors'
 
 interface InputProps extends TextInputProps {
   label?: string
@@ -25,6 +26,9 @@ export const Input = forwardRef<TextInput, InputProps>(
     { label, error, containerStyle, leftIcon, rightIcon, style, ...props },
     ref
   ) => {
+    const colors = useThemeColors()
+    const styles = React.useMemo(() => createStyles(colors), [colors])
+
     return (
       <View style={[styles.container, containerStyle]}>
         {label && <Text style={styles.label}>{label}</Text>}
@@ -39,7 +43,7 @@ export const Input = forwardRef<TextInput, InputProps>(
               error && styles.inputError,
               style,
             ]}
-            placeholderTextColor={Colors.textTertiary}
+            placeholderTextColor={colors.textTertiary}
             {...props}
           />
           {rightIcon && <View style={styles.rightIcon}>{rightIcon}</View>}
@@ -52,62 +56,63 @@ export const Input = forwardRef<TextInput, InputProps>(
 
 Input.displayName = 'Input'
 
-const styles = StyleSheet.create({
-  container: {
-    width: '100%',
-  },
+const createStyles = (colors: ThemeColors) =>
+  StyleSheet.create({
+    container: {
+      width: '100%',
+    },
 
-  label: {
-    ...Typography.textStyles.body,
-    color: Colors.text,
-    marginBottom: Spacing.xs,
-  },
+    label: {
+      ...Typography.textStyles.body,
+      color: colors.text,
+      marginBottom: Spacing.xs,
+    },
 
-  inputContainer: {
-    position: 'relative',
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
+    inputContainer: {
+      position: 'relative',
+      flexDirection: 'row',
+      alignItems: 'center',
+    },
 
-  input: {
-    height: Spacing.inputHeight,
-    backgroundColor: Colors.surface,
-    borderRadius: BorderRadius.md,
-    paddingHorizontal: Spacing.md,
-    color: Colors.text,
-    ...Typography.textStyles.body,
-    flex: 1,
-    borderWidth: 1,
-    borderColor: Colors.border,
-  },
+    input: {
+      height: Spacing.inputHeight,
+      backgroundColor: colors.surface,
+      borderRadius: BorderRadius.md,
+      paddingHorizontal: Spacing.md,
+      color: colors.text,
+      ...Typography.textStyles.body,
+      flex: 1,
+      borderWidth: 1,
+      borderColor: colors.border,
+    },
 
-  inputWithLeftIcon: {
-    paddingLeft: Spacing.xxl,
-  },
+    inputWithLeftIcon: {
+      paddingLeft: Spacing.xxl,
+    },
 
-  inputWithRightIcon: {
-    paddingRight: Spacing.xxl,
-  },
+    inputWithRightIcon: {
+      paddingRight: Spacing.xxl,
+    },
 
-  inputError: {
-    borderColor: Colors.error,
-  },
+    inputError: {
+      borderColor: colors.error,
+    },
 
-  leftIcon: {
-    position: 'absolute',
-    left: Spacing.md,
-    zIndex: 1,
-  },
+    leftIcon: {
+      position: 'absolute',
+      left: Spacing.md,
+      zIndex: 1,
+    },
 
-  rightIcon: {
-    position: 'absolute',
-    right: Spacing.md,
-    zIndex: 1,
-  },
+    rightIcon: {
+      position: 'absolute',
+      right: Spacing.md,
+      zIndex: 1,
+    },
 
-  error: {
-    ...Typography.textStyles.caption,
-    color: Colors.error,
-    marginTop: Spacing.xs,
-  },
-})
+    error: {
+      ...Typography.textStyles.caption,
+      color: colors.error,
+      marginTop: Spacing.xs,
+    },
+  })

--- a/components/ui/ListItem.tsx
+++ b/components/ui/ListItem.tsx
@@ -8,9 +8,10 @@ import {
   ViewStyle,
 } from 'react-native'
 
-import { Colors } from '@/constants/Colors'
+import { type ThemeColors } from '@/constants/Colors'
 import { Spacing, BorderRadius, Shadows } from '@/constants/Layout'
 import { Typography } from '@/constants/Typography'
+import { useThemeColors } from '@/hooks/useThemeColors'
 
 interface ListItemProps {
   title: string
@@ -37,6 +38,9 @@ export const ListItem: React.FC<ListItemProps> = ({
   hasUrl = false,
   hasImage = false,
 }) => {
+  const colors = useThemeColors()
+  const styles = React.useMemo(() => createStyles(colors), [colors])
+
   return (
     <TouchableOpacity
       style={[styles.container, style]}
@@ -55,7 +59,7 @@ export const ListItem: React.FC<ListItemProps> = ({
               <Ionicons
                 name="link"
                 size={16}
-                color={Colors.textSecondary}
+                color={colors.textSecondary}
                 style={styles.attachment}
               />
             )}
@@ -63,7 +67,7 @@ export const ListItem: React.FC<ListItemProps> = ({
               <Ionicons
                 name="image"
                 size={16}
-                color={Colors.textSecondary}
+                color={colors.textSecondary}
                 style={styles.attachment}
               />
             )}
@@ -87,7 +91,7 @@ export const ListItem: React.FC<ListItemProps> = ({
             <Ionicons
               name="chevron-forward"
               size={20}
-              color={Colors.textSecondary}
+              color={colors.textSecondary}
             />
           )}
         </View>
@@ -96,58 +100,59 @@ export const ListItem: React.FC<ListItemProps> = ({
   )
 }
 
-const styles = StyleSheet.create({
-  container: {
-    backgroundColor: Colors.surface,
-    borderRadius: BorderRadius.md,
-    marginVertical: Spacing.xs,
-    ...Shadows.small,
-  },
+const createStyles = (colors: ThemeColors) =>
+  StyleSheet.create({
+    container: {
+      backgroundColor: colors.surface,
+      borderRadius: BorderRadius.md,
+      marginVertical: Spacing.xs,
+      ...Shadows.small,
+    },
 
-  content: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingVertical: Spacing.md,
-    paddingHorizontal: Spacing.md,
-    minHeight: Spacing.listItemHeight,
-  },
+    content: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingVertical: Spacing.md,
+      paddingHorizontal: Spacing.md,
+      minHeight: Spacing.listItemHeight,
+    },
 
-  leftSection: {
-    marginRight: Spacing.md,
-  },
+    leftSection: {
+      marginRight: Spacing.md,
+    },
 
-  middleSection: {
-    flex: 1,
-  },
+    middleSection: {
+      flex: 1,
+    },
 
-  rightSection: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginLeft: Spacing.md,
-  },
+    rightSection: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      marginLeft: Spacing.md,
+    },
 
-  attachmentsRow: {
-    flexDirection: 'row',
-    marginBottom: Spacing.xs,
-  },
+    attachmentsRow: {
+      flexDirection: 'row',
+      marginBottom: Spacing.xs,
+    },
 
-  attachment: {
-    marginRight: Spacing.xs,
-  },
+    attachment: {
+      marginRight: Spacing.xs,
+    },
 
-  title: {
-    ...Typography.textStyles.body,
-    color: Colors.text,
-  },
+    title: {
+      ...Typography.textStyles.body,
+      color: colors.text,
+    },
 
-  completedTitle: {
-    textDecorationLine: 'line-through',
-    color: Colors.textSecondary,
-  },
+    completedTitle: {
+      textDecorationLine: 'line-through',
+      color: colors.textSecondary,
+    },
 
-  subtitle: {
-    ...Typography.textStyles.caption,
-    color: Colors.textSecondary,
-    marginTop: Spacing.xs,
-  },
-})
+    subtitle: {
+      ...Typography.textStyles.caption,
+      color: colors.textSecondary,
+      marginTop: Spacing.xs,
+    },
+  })

--- a/components/ui/ProgressChip.tsx
+++ b/components/ui/ProgressChip.tsx
@@ -2,9 +2,9 @@ import React from 'react'
 import { View, Text, StyleSheet } from 'react-native'
 import Svg, { Circle } from 'react-native-svg'
 
-import { Colors } from '@/constants/Colors'
 import { Spacing } from '@/constants/Layout'
 import { Typography } from '@/constants/Typography'
+import { useThemeColors } from '@/hooks/useThemeColors'
 
 interface ProgressChipProps {
   completed: number
@@ -19,6 +19,7 @@ export const ProgressChip: React.FC<ProgressChipProps> = ({
   size,
   variant = 'small',
 }) => {
+  const colors = useThemeColors()
   // 根据变体设置默认大小和线宽
   const defaultSize = variant === 'large' ? 60 : Spacing.progressChipSize
   const actualSize = size || defaultSize
@@ -31,9 +32,8 @@ export const ProgressChip: React.FC<ProgressChipProps> = ({
   const strokeDashoffset = circumference - progress * circumference
   const isComplete = completed === total && total > 0
 
-  // Figma颜色规格
-  const completedColor = '#2ECC71' // 完成色
-  const uncompletedColor = '#6F6F6F' // 未完成色
+  const completedColor = colors.success
+  const uncompletedColor = colors.textSecondary
 
   return (
     <View style={[styles.container, { width: actualSize, height: actualSize }]}>
@@ -63,7 +63,12 @@ export const ProgressChip: React.FC<ProgressChipProps> = ({
           />
         )}
       </Svg>
-      <Text style={[styles.text, { fontSize: actualSize * 0.25 }]}>
+      <Text
+        style={[
+          styles.text,
+          { color: colors.text, fontSize: actualSize * 0.25 },
+        ]}
+      >
         {completed}/{total}
       </Text>
     </View>
@@ -83,7 +88,6 @@ const styles = StyleSheet.create({
 
   text: {
     ...Typography.textStyles.caption,
-    color: Colors.text,
     fontWeight: Typography.fontWeight.semibold,
     textAlign: 'center',
   },

--- a/constants/Colors.ts
+++ b/constants/Colors.ts
@@ -1,33 +1,50 @@
 /**
  * Shopper App Color Palette
- * Dark theme with teal-green primary color as per design spec
+ * Supports light and dark themes with teal-green primary color
  */
 
-export const Colors = {
-  // Primary colors
-  primary: '#20B2A6', // Teal-green for CTAs, checkmarks, progress rings
+const lightColors = {
+  primary: '#20B2A6',
   primaryDark: '#1A9B8F',
+  tint: '#20B2A6',
+  background: '#FFFFFF',
+  surface: '#F2F2F2',
+  surfaceElevated: '#E5E5E5',
+  text: '#000000',
+  textSecondary: '#4A4A4A',
+  textTertiary: '#6B6B6B',
+  success: '#20B2A6',
+  error: '#FF3B30',
+  warning: '#FF9500',
+  inactive: '#C5C5C7',
+  border: '#E0E0E0',
+  overlay: 'rgba(0, 0, 0, 0.1)',
+  shadow: 'rgba(0, 0, 0, 0.2)',
+}
 
-  // Surface colors
-  background: '#0A0A0B', // Near-black background
-  surface: '#1A1A1C', // Slightly lighter for cards/lists
-  surfaceElevated: '#2A2A2C', // For elevated components
-
-  // Text colors
-  text: '#FFFFFF', // High-contrast light text
-  textSecondary: '#9B9B9B', // Muted gray for secondary text
-  textTertiary: '#6B6B6B', // Even more muted for hints
-
-  // State colors
-  success: '#20B2A6', // Same as primary for consistency
+const darkColors = {
+  primary: '#20B2A6',
+  primaryDark: '#1A9B8F',
+  tint: '#20B2A6',
+  background: '#0A0A0B',
+  surface: '#1A1A1C',
+  surfaceElevated: '#2A2A2C',
+  text: '#FFFFFF',
+  textSecondary: '#9B9B9B',
+  textTertiary: '#6B6B6B',
+  success: '#20B2A6',
   error: '#FF6B6B',
   warning: '#FFB366',
-
-  // Interactive colors
-  inactive: '#4A4A4C', // For inactive states, hollow circles
-  border: '#2A2A2C', // For borders and separators
-
-  // Special colors
-  overlay: 'rgba(0, 0, 0, 0.7)', // For modals/overlays
-  shadow: 'rgba(0, 0, 0, 0.3)', // For shadows
+  inactive: '#4A4A4C',
+  border: '#2A2A2C',
+  overlay: 'rgba(0, 0, 0, 0.7)',
+  shadow: 'rgba(0, 0, 0, 0.3)',
 }
+
+export const Colors = {
+  light: lightColors,
+  dark: darkColors,
+  ...darkColors, // default for backward compatibility
+} as const
+
+export type ThemeColors = typeof lightColors

--- a/constants/Colors.ts
+++ b/constants/Colors.ts
@@ -41,10 +41,13 @@ const darkColors = {
   shadow: 'rgba(0, 0, 0, 0.3)',
 }
 
-export const Colors = {
+const Colors = {
   light: lightColors,
   dark: darkColors,
   ...darkColors, // default for backward compatibility
 } as const
 
 export type ThemeColors = typeof lightColors
+
+export { Colors }
+export default Colors

--- a/context/ThemeContext.tsx
+++ b/context/ThemeContext.tsx
@@ -1,0 +1,55 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import React, { createContext, useContext, useEffect, useState } from 'react'
+import {
+  ColorSchemeName,
+  useColorScheme as useRNColorScheme,
+} from 'react-native'
+
+export type ThemePreference = 'light' | 'dark' | 'system'
+
+interface ThemeContextValue {
+  theme: NonNullable<ColorSchemeName>
+  themePreference: ThemePreference
+  setThemePreference: (pref: ThemePreference) => void
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: 'light',
+  themePreference: 'system',
+  setThemePreference: () => {},
+})
+
+const STORAGE_KEY = 'theme-preference'
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const systemScheme = useRNColorScheme() ?? 'light'
+  const [themePreference, setThemePreference] =
+    useState<ThemePreference>('system')
+
+  useEffect(() => {
+    AsyncStorage.getItem(STORAGE_KEY).then(value => {
+      if (value === 'light' || value === 'dark' || value === 'system') {
+        setThemePreference(value)
+      }
+    })
+  }, [])
+
+  const setPreference = (pref: ThemePreference) => {
+    setThemePreference(pref)
+    AsyncStorage.setItem(STORAGE_KEY, pref).catch(() => {})
+  }
+
+  const theme = themePreference === 'system' ? systemScheme : themePreference
+
+  return (
+    <ThemeContext.Provider
+      value={{ theme, themePreference, setThemePreference: setPreference }}
+    >
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+export const useTheme = () => useContext(ThemeContext)

--- a/hooks/useColorScheme.ts
+++ b/hooks/useColorScheme.ts
@@ -1,1 +1,6 @@
-export { useColorScheme } from 'react-native'
+import { useTheme } from '@/context/ThemeContext'
+
+export function useColorScheme() {
+  const { theme } = useTheme()
+  return theme
+}

--- a/hooks/useColorScheme.web.ts
+++ b/hooks/useColorScheme.web.ts
@@ -1,21 +1,6 @@
-import { useEffect, useState } from 'react'
-import { useColorScheme as useRNColorScheme } from 'react-native'
+import { useTheme } from '@/context/ThemeContext'
 
-/**
- * To support static rendering, this value needs to be re-calculated on the client side for web
- */
 export function useColorScheme() {
-  const [hasHydrated, setHasHydrated] = useState(false)
-
-  useEffect(() => {
-    setHasHydrated(true)
-  }, [])
-
-  const colorScheme = useRNColorScheme()
-
-  if (hasHydrated) {
-    return colorScheme
-  }
-
-  return 'light'
+  const { theme } = useTheme()
+  return theme
 }

--- a/hooks/useThemeColors.ts
+++ b/hooks/useThemeColors.ts
@@ -1,0 +1,7 @@
+import { Colors, type ThemeColors } from '@/constants/Colors'
+import { useColorScheme } from '@/hooks/useColorScheme'
+
+export function useThemeColors(): ThemeColors {
+  const scheme = useColorScheme() === 'dark' ? 'dark' : 'light'
+  return Colors[scheme]
+}


### PR DESCRIPTION
## Summary
- add light color palette and theme context to control system/adaptive or explicit modes
- wire theme provider into root and tab layouts
- expose theme switcher in Settings so users can pick system, dark, or light

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4970b19988323912d27d658ecfb99