### PR TITLE
feat(list): rename list from detail page

### DIFF
--- a/app/(app)/list/[id].tsx
+++ b/app/(app)/list/[id].tsx
@@ -337,7 +337,7 @@ export default function ListDetailScreen() {
                 style={styles.renameButton}
                 onPress={handleRenameList}
               >
-                <Ionicons name="create-outline" size={20} color={Colors.text} />
+                <Ionicons name="create-outline" size={24} color={Colors.text} />
               </TouchableOpacity>
             </View>
 
@@ -428,7 +428,7 @@ export default function ListDetailScreen() {
               style={styles.renameButton}
               onPress={handleRenameList}
             >
-              <Ionicons name="create-outline" size={20} color={Colors.text} />
+              <Ionicons name="create-outline" size={24} color={Colors.text} />
             </TouchableOpacity>
           </View>
 
@@ -546,7 +546,11 @@ const styles = StyleSheet.create({
   },
 
   renameButton: {
-    padding: 4,
+    width: 44,
+    height: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginLeft: 8,
   },
 
   content: {

--- a/app/(app)/list/[id].tsx
+++ b/app/(app)/list/[id].tsx
@@ -152,9 +152,11 @@ export default function ListDetailScreen() {
               <Ionicons name="chevron-back" size={24} color={Colors.text} />
             </TouchableOpacity>
 
-            <Text style={styles.headerTitle} numberOfLines={1}>
-              List Not Found
-            </Text>
+            <View style={styles.titleContainer}>
+              <Text style={styles.headerTitle} numberOfLines={1}>
+                List Not Found
+              </Text>
+            </View>
 
             <View style={styles.headerRight} />
           </View>
@@ -327,9 +329,17 @@ export default function ListDetailScreen() {
               <Ionicons name="chevron-back" size={24} color={Colors.text} />
             </TouchableOpacity>
 
-            <Text style={styles.headerTitle} numberOfLines={1}>
-              {list.name}
-            </Text>
+            <View style={styles.titleContainer}>
+              <Text style={styles.headerTitle} numberOfLines={1}>
+                {list.name}
+              </Text>
+              <TouchableOpacity
+                style={styles.renameButton}
+                onPress={handleRenameList}
+              >
+                <Ionicons name="create-outline" size={20} color={Colors.text} />
+              </TouchableOpacity>
+            </View>
 
             <View style={styles.headerRight}>
               <ProgressChip
@@ -410,9 +420,17 @@ export default function ListDetailScreen() {
             <Ionicons name="chevron-back" size={24} color={Colors.text} />
           </TouchableOpacity>
 
-          <Text style={styles.headerTitle} numberOfLines={1}>
-            {list.name}
-          </Text>
+          <View style={styles.titleContainer}>
+            <Text style={styles.headerTitle} numberOfLines={1}>
+              {list.name}
+            </Text>
+            <TouchableOpacity
+              style={styles.renameButton}
+              onPress={handleRenameList}
+            >
+              <Ionicons name="create-outline" size={20} color={Colors.text} />
+            </TouchableOpacity>
+          </View>
 
           <View style={styles.headerRight}>
             <ProgressChip
@@ -504,6 +522,12 @@ const styles = StyleSheet.create({
     fontWeight: Typography.fontWeight.semibold,
     color: Colors.text,
     flex: 1,
+  },
+
+  titleContainer: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
     marginLeft: 12,
     marginRight: 16,
   },
@@ -519,6 +543,10 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     marginLeft: 8,
+  },
+
+  renameButton: {
+    padding: 4,
   },
 
   content: {

--- a/app/(app)/list/[id].tsx
+++ b/app/(app)/list/[id].tsx
@@ -1,6 +1,6 @@
 import { Ionicons } from '@expo/vector-icons'
 import { useRouter, useLocalSearchParams, Stack } from 'expo-router'
-import React from 'react'
+import React, { useState } from 'react'
 import {
   View,
   Text,
@@ -9,13 +9,20 @@ import {
   StyleSheet,
   Alert,
   Image,
+  Modal,
 } from 'react-native'
 import { Swipeable } from 'react-native-gesture-handler'
 import { SafeAreaView } from 'react-native-safe-area-context'
 
-import { EmptyState, Button, Checkbox, ProgressChip } from '@/components/ui'
+import {
+  EmptyState,
+  Button,
+  Checkbox,
+  ProgressChip,
+  Input,
+} from '@/components/ui'
 import { Colors } from '@/constants/Colors'
-import { Spacing } from '@/constants/Layout'
+import { Spacing, BorderRadius } from '@/constants/Layout'
 import { Typography } from '@/constants/Typography'
 import { useApp } from '@/context/AppContext'
 import { ShoppingItem } from '@/types'
@@ -27,6 +34,25 @@ export default function ListDetailScreen() {
 
   const { getList, dispatch } = useApp()
   const list = getList(listId)
+
+  const [isRenameModalVisible, setRenameModalVisible] = useState(false)
+  const [newListName, setNewListName] = useState('')
+
+  const handleRenameList = () => {
+    setNewListName(list?.name || '')
+    setRenameModalVisible(true)
+  }
+
+  const handleSaveListName = () => {
+    const trimmed = newListName.trim()
+    if (trimmed) {
+      dispatch({
+        type: 'UPDATE_LIST',
+        payload: { id: listId, name: trimmed },
+      })
+    }
+    setRenameModalVisible(false)
+  }
 
   const completedCount = list
     ? list.items.filter(item => item.isCompleted).length
@@ -73,6 +99,41 @@ export default function ListDetailScreen() {
       ]
     )
   }
+
+  const renameModal = (
+    <Modal
+      visible={isRenameModalVisible}
+      animationType="fade"
+      transparent
+      onRequestClose={() => setRenameModalVisible(false)}
+    >
+      <View style={styles.modalOverlay}>
+        <View style={styles.modalContent}>
+          <Text style={styles.modalTitle}>Rename List</Text>
+          <Input
+            value={newListName}
+            onChangeText={setNewListName}
+            placeholder="List name"
+            autoFocus
+            containerStyle={styles.modalInput}
+          />
+          <View style={styles.modalButtons}>
+            <Button
+              title="Cancel"
+              variant="secondary"
+              onPress={() => setRenameModalVisible(false)}
+              style={styles.modalButton}
+            />
+            <Button
+              title="Save"
+              onPress={handleSaveListName}
+              style={styles.modalButton}
+            />
+          </View>
+        </View>
+      </View>
+    </Modal>
+  )
 
   if (!list) {
     return (
@@ -285,6 +346,10 @@ export default function ListDetailScreen() {
                     'Choose an action for this list',
                     [
                       {
+                        text: 'Rename List',
+                        onPress: handleRenameList,
+                      },
+                      {
                         text: 'Archive List',
                         onPress: handleArchiveList,
                       },
@@ -324,6 +389,7 @@ export default function ListDetailScreen() {
             }
           />
         </SafeAreaView>
+        {renameModal}
       </>
     )
   }
@@ -359,6 +425,10 @@ export default function ListDetailScreen() {
               style={styles.menuButton}
               onPress={() => {
                 Alert.alert('List Options', 'Choose an action for this list', [
+                  {
+                    text: 'Rename List',
+                    onPress: handleRenameList,
+                  },
                   {
                     text: 'Archive List',
                     onPress: handleArchiveList,
@@ -402,6 +472,7 @@ export default function ListDetailScreen() {
           <Button title="+ Add Item" onPress={handleAddItem} fullWidth />
         </View>
       </SafeAreaView>
+      {renameModal}
     </>
   )
 }
@@ -560,5 +631,40 @@ const styles = StyleSheet.create({
   emptyImage: {
     width: 180,
     height: 120,
+  },
+
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: Spacing.lg,
+  },
+
+  modalContent: {
+    width: '100%',
+    backgroundColor: Colors.surface,
+    borderRadius: BorderRadius.lg,
+    padding: Spacing.lg,
+  },
+
+  modalTitle: {
+    fontSize: 20,
+    fontWeight: Typography.fontWeight.semibold,
+    color: Colors.text,
+  },
+
+  modalInput: {
+    marginTop: Spacing.md,
+  },
+
+  modalButtons: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    marginTop: Spacing.md,
+  },
+
+  modalButton: {
+    marginLeft: Spacing.sm,
   },
 })

--- a/app/(app)/list/[id].tsx
+++ b/app/(app)/list/[id].tsx
@@ -527,17 +527,16 @@ const styles = StyleSheet.create({
   },
 
   titleContainer: {
-    flex: 1,
     flexDirection: 'row',
     alignItems: 'center',
-    marginLeft: 12,
-    marginRight: 16,
-    justifyContent: 'center',
+    marginLeft: 4,
+    flexShrink: 1,
   },
 
   headerRight: {
     flexDirection: 'row',
     alignItems: 'center',
+    marginLeft: 'auto',
   },
 
   menuButton: {

--- a/app/(app)/list/[id].tsx
+++ b/app/(app)/list/[id].tsx
@@ -336,6 +336,7 @@ export default function ListDetailScreen() {
               <TouchableOpacity
                 style={styles.renameButton}
                 onPress={handleRenameList}
+                hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
               >
                 <Ionicons name="create-outline" size={24} color={Colors.text} />
               </TouchableOpacity>
@@ -427,6 +428,7 @@ export default function ListDetailScreen() {
             <TouchableOpacity
               style={styles.renameButton}
               onPress={handleRenameList}
+              hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
             >
               <Ionicons name="create-outline" size={24} color={Colors.text} />
             </TouchableOpacity>
@@ -521,7 +523,7 @@ const styles = StyleSheet.create({
     fontSize: 24,
     fontWeight: Typography.fontWeight.semibold,
     color: Colors.text,
-    flex: 1,
+    flexShrink: 1,
   },
 
   titleContainer: {
@@ -530,6 +532,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     marginLeft: 12,
     marginRight: 16,
+    justifyContent: 'center',
   },
 
   headerRight: {
@@ -546,11 +549,11 @@ const styles = StyleSheet.create({
   },
 
   renameButton: {
-    width: 44,
-    height: 44,
+    width: 24,
+    height: 24,
     alignItems: 'center',
     justifyContent: 'center',
-    marginLeft: 8,
+    marginLeft: 4,
   },
 
   content: {


### PR DESCRIPTION
## Summary
- allow shopping lists to be renamed via a modal on the list detail screen
- add rename option to list actions menu

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b49857fdec83239b9e35161b1871bd