### PR TITLE
refactor: use textSecondary for collapsible icon

### DIFF
--- a/components/Collapsible.tsx
+++ b/components/Collapsible.tsx
@@ -25,7 +25,11 @@ export function Collapsible({
           name="chevron.right"
           size={18}
           weight="medium"
-          color={theme === 'light' ? Colors.light.icon : Colors.dark.icon}
+          color={
+            theme === 'light'
+              ? Colors.light.textSecondary
+              : Colors.dark.textSecondary
+          }
           style={{ transform: [{ rotate: isOpen ? '90deg' : '0deg' }] }}
         />
 


### PR DESCRIPTION
## Summary
- use textSecondary color for Collapsible icon based on theme

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b51fd469688323a4c6b9dce1a47100