### PR TITLE
refactor: use theme colors

### DIFF
--- a/app/(app)/_layout.tsx
+++ b/app/(app)/_layout.tsx
@@ -1,14 +1,15 @@
 import { Stack } from 'expo-router'
 import React from 'react'
 
-import { Colors } from '@/constants/Colors'
+import { useThemeColors } from '@/hooks/useThemeColors'
 
 export default function AppLayout() {
+  const colors = useThemeColors()
   return (
     <Stack
       screenOptions={{
         headerShown: false,
-        contentStyle: { backgroundColor: Colors.background },
+        contentStyle: { backgroundColor: colors.background },
       }}
     >
       <Stack.Screen name="lists" />

--- a/app/(app)/archived-lists.tsx
+++ b/app/(app)/archived-lists.tsx
@@ -1,13 +1,12 @@
-import { Ionicons } from '@expo/vector-icons'
 import { useRouter } from 'expo-router'
 import React from 'react'
 import { View, FlatList, StyleSheet, Image } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 
 import { Header, EmptyState, Button, ArchiveListCard } from '@/components/ui'
-import { Colors } from '@/constants/Colors'
 import { Spacing } from '@/constants/Layout'
 import { useApp } from '@/context/AppContext'
+import { useThemeColors } from '@/hooks/useThemeColors'
 import { ShoppingList } from '@/types'
 import { getListPreview, getCompletedCount } from '@/utils/listHelpers'
 
@@ -15,6 +14,7 @@ export default function ArchivedListsScreen() {
   const router = useRouter()
   const { getArchivedLists, dispatch } = useApp()
   const archivedLists = getArchivedLists()
+  const colors = useThemeColors()
 
   const handleRestoreList = (listId: string) => {
     dispatch({ type: 'RESTORE_LIST', payload: { id: listId } })
@@ -44,7 +44,9 @@ export default function ArchivedListsScreen() {
 
   if (archivedLists.length === 0) {
     return (
-      <SafeAreaView style={styles.container}>
+      <SafeAreaView
+        style={[styles.container, { backgroundColor: colors.background }]}
+      >
         <Header
           title="Archived Lists"
           showBackButton
@@ -71,7 +73,9 @@ export default function ArchivedListsScreen() {
   }
 
   return (
-    <SafeAreaView style={styles.container}>
+    <SafeAreaView
+      style={[styles.container, { backgroundColor: colors.background }]}
+    >
       <Header
         title="Archived Lists"
         showBackButton
@@ -92,7 +96,6 @@ export default function ArchivedListsScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: Colors.background,
   },
 
   emptyContainer: {

--- a/app/(app)/create-list.tsx
+++ b/app/(app)/create-list.tsx
@@ -14,15 +14,16 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context'
 
 import { Header, Input, Button } from '@/components/ui'
-import { Colors } from '@/constants/Colors'
 import { Spacing } from '@/constants/Layout'
 import { useApp } from '@/context/AppContext'
+import { useThemeColors } from '@/hooks/useThemeColors'
 
 export default function CreateListScreen() {
   const [listName, setListName] = useState('')
   const [keyboardVisible, setKeyboardVisible] = useState(false)
   const router = useRouter()
   const { dispatch, state } = useApp()
+  const colors = useThemeColors()
 
   // Animation values
   const illustrationScale = useRef(new Animated.Value(1)).current
@@ -111,7 +112,9 @@ export default function CreateListScreen() {
   }
 
   return (
-    <SafeAreaView style={styles.container}>
+    <SafeAreaView
+      style={[styles.container, { backgroundColor: colors.background }]}
+    >
       <Header
         title="Name your list"
         showBackButton
@@ -192,7 +195,6 @@ export default function CreateListScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: Colors.background,
   },
 
   keyboardAvoidingView: {

--- a/app/(app)/trash.tsx
+++ b/app/(app)/trash.tsx
@@ -13,10 +13,10 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context'
 
 import { Header, EmptyState, Button, ArchiveListCard } from '@/components/ui'
-import { Colors } from '@/constants/Colors'
 import { Spacing } from '@/constants/Layout'
 import { Typography } from '@/constants/Typography'
 import { useApp } from '@/context/AppContext'
+import { useThemeColors } from '@/hooks/useThemeColors'
 import { ShoppingList } from '@/types'
 import { HapticFeedback } from '@/utils/haptics'
 import {
@@ -29,6 +29,7 @@ export default function TrashScreen() {
   const router = useRouter()
   const { getDeletedLists, dispatch } = useApp()
   const deletedLists = getDeletedLists()
+  const colors = useThemeColors()
 
   const handleRestoreList = (listId: string) => {
     dispatch({ type: 'RESTORE_LIST', payload: { id: listId } })
@@ -86,7 +87,9 @@ export default function TrashScreen() {
 
   if (deletedLists.length === 0) {
     return (
-      <SafeAreaView style={styles.container}>
+      <SafeAreaView
+        style={[styles.container, { backgroundColor: colors.background }]}
+      >
         <Header
           title="Trash"
           showBackButton
@@ -113,20 +116,29 @@ export default function TrashScreen() {
   }
 
   return (
-    <SafeAreaView style={styles.container}>
+    <SafeAreaView
+      style={[styles.container, { backgroundColor: colors.background }]}
+    >
       <Header
         title="Trash"
         showBackButton
         onBackPress={() => router.back()}
         rightComponent={
           <TouchableOpacity onPress={handleEmptyTrash}>
-            <Text style={styles.emptyTrashText}>Empty</Text>
+            <Text style={[styles.emptyTrashText, { color: colors.error }]}>
+              Empty
+            </Text>
           </TouchableOpacity>
         }
       />
 
-      <View style={styles.infoContainer}>
-        <Text style={styles.infoText}>
+      <View
+        style={[
+          styles.infoContainer,
+          { backgroundColor: colors.surface, borderBottomColor: colors.border },
+        ]}
+      >
+        <Text style={[styles.infoText, { color: colors.textSecondary }]}>
           Items in trash are automatically deleted after 30 days
         </Text>
       </View>
@@ -145,7 +157,6 @@ export default function TrashScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: Colors.background,
   },
 
   emptyContainer: {
@@ -160,20 +171,16 @@ const styles = StyleSheet.create({
   infoContainer: {
     paddingHorizontal: Spacing.screenPadding,
     paddingVertical: Spacing.md,
-    backgroundColor: Colors.surface,
     borderBottomWidth: 1,
-    borderBottomColor: Colors.border,
   },
 
   infoText: {
     ...Typography.textStyles.caption,
-    color: Colors.textSecondary,
     textAlign: 'center',
   },
 
   emptyTrashText: {
     ...Typography.textStyles.body,
-    color: Colors.error,
     fontWeight: Typography.fontWeight.semibold,
   },
 

--- a/app/(onboarding)/_layout.tsx
+++ b/app/(onboarding)/_layout.tsx
@@ -1,14 +1,15 @@
 import { Stack } from 'expo-router'
 import React from 'react'
 
-import { Colors } from '@/constants/Colors'
+import { useThemeColors } from '@/hooks/useThemeColors'
 
 export default function OnboardingLayout() {
+  const colors = useThemeColors()
   return (
     <Stack
       screenOptions={{
         headerShown: false,
-        contentStyle: { backgroundColor: Colors.background },
+        contentStyle: { backgroundColor: colors.background },
       }}
     >
       <Stack.Screen name="onboarding" />

--- a/app/(onboarding)/onboarding.tsx
+++ b/app/(onboarding)/onboarding.tsx
@@ -5,10 +5,10 @@ import PagerView from 'react-native-pager-view'
 import { SafeAreaView } from 'react-native-safe-area-context'
 
 import { Button } from '@/components/ui'
-import { Colors } from '@/constants/Colors'
 import { Spacing } from '@/constants/Layout'
 import { Typography } from '@/constants/Typography'
 import { useApp } from '@/context/AppContext'
+import { useThemeColors } from '@/hooks/useThemeColors'
 
 const { width } = Dimensions.get('window')
 
@@ -24,46 +24,60 @@ const OnboardingPage: React.FC<OnboardingPageProps> = ({
   headline,
   body,
   imageSource,
-}) => (
-  <View style={styles.page}>
-    <Text style={styles.title}>{title}</Text>
+}) => {
+  const colors = useThemeColors()
+  return (
+    <View style={styles.page}>
+      <Text style={[styles.title, { color: colors.text }]}>{title}</Text>
 
-    <View style={styles.imageContainer}>
-      <Image
-        source={imageSource}
-        style={styles.illustration}
-        resizeMode="contain"
-      />
-    </View>
+      <View style={styles.imageContainer}>
+        <Image
+          source={imageSource}
+          style={styles.illustration}
+          resizeMode="contain"
+        />
+      </View>
 
-    <View style={styles.textContainer}>
-      <Text style={styles.headline}>{headline}</Text>
-      <Text style={styles.body}>{body}</Text>
+      <View style={styles.textContainer}>
+        <Text style={[styles.headline, { color: colors.text }]}>
+          {headline}
+        </Text>
+        <Text style={[styles.body, { color: colors.textSecondary }]}>
+          {body}
+        </Text>
+      </View>
     </View>
-  </View>
-)
+  )
+}
 
 const CarouselDots: React.FC<{ activeIndex: number; total: number }> = ({
   activeIndex,
   total,
-}) => (
-  <View style={styles.dotsContainer}>
-    {Array.from({ length: total }).map((_, index) => (
-      <View
-        key={index}
-        style={[
-          styles.dot,
-          index === activeIndex ? styles.activeDot : styles.inactiveDot,
-        ]}
-      />
-    ))}
-  </View>
-)
+}) => {
+  const colors = useThemeColors()
+  return (
+    <View style={styles.dotsContainer}>
+      {Array.from({ length: total }).map((_, index) => (
+        <View
+          key={index}
+          style={[
+            styles.dot,
+            {
+              backgroundColor:
+                index === activeIndex ? colors.primary : colors.inactive,
+            },
+          ]}
+        />
+      ))}
+    </View>
+  )
+}
 
 export default function OnboardingScreen() {
   const [currentPage, setCurrentPage] = useState(0)
   const router = useRouter()
   const { dispatch } = useApp()
+  const colors = useThemeColors()
 
   const onboardingData: OnboardingPageProps[] = [
     {
@@ -92,7 +106,9 @@ export default function OnboardingScreen() {
   }
 
   return (
-    <SafeAreaView style={styles.container}>
+    <SafeAreaView
+      style={[styles.container, { backgroundColor: colors.background }]}
+    >
       <PagerView
         style={styles.pager}
         initialPage={0}
@@ -120,7 +136,6 @@ export default function OnboardingScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: Colors.background,
   },
 
   pager: {
@@ -136,7 +151,6 @@ const styles = StyleSheet.create({
 
   title: {
     ...Typography.textStyles.largeTitle,
-    color: Colors.text,
     position: 'absolute',
     top: Spacing.xl,
     fontWeight: Typography.fontWeight.bold,
@@ -161,7 +175,6 @@ const styles = StyleSheet.create({
 
   headline: {
     ...Typography.textStyles.title,
-    color: Colors.text,
     textAlign: 'center',
     marginBottom: Spacing.md,
     fontWeight: Typography.fontWeight.semibold,
@@ -169,7 +182,6 @@ const styles = StyleSheet.create({
 
   body: {
     ...Typography.textStyles.body,
-    color: Colors.textSecondary,
     textAlign: 'center',
   },
 
@@ -192,13 +204,5 @@ const styles = StyleSheet.create({
     height: 8,
     borderRadius: 4,
     marginHorizontal: 4,
-  },
-
-  activeDot: {
-    backgroundColor: Colors.primary,
-  },
-
-  inactiveDot: {
-    backgroundColor: Colors.inactive,
   },
 })

--- a/app/(tabs)/explore.tsx
+++ b/app/(tabs)/explore.tsx
@@ -8,8 +8,10 @@ import { ThemedText } from '@/components/ThemedText'
 import { ThemedView } from '@/components/ThemedView'
 import { IconSymbol } from '@/components/ui/IconSymbol'
 import { Colors } from '@/constants/Colors'
+import { useThemeColors } from '@/hooks/useThemeColors'
 
 export default function TabTwoScreen() {
+  const colors = useThemeColors()
   return (
     <ParallaxScrollView
       headerBackgroundColor={{
@@ -19,7 +21,7 @@ export default function TabTwoScreen() {
       headerImage={
         <IconSymbol
           size={310}
-          color={Colors.textSecondary}
+          color={colors.textSecondary}
           name="chevron.left.forwardslash.chevron.right"
           style={styles.headerImage}
         />

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -6,10 +6,12 @@ import { Colors } from '@/constants/Colors'
 import { Spacing } from '@/constants/Layout'
 import { Typography } from '@/constants/Typography'
 import { useApp } from '@/context/AppContext'
+import { useThemeColors } from '@/hooks/useThemeColors'
 
 export default function SplashScreen() {
   const router = useRouter()
   const { state } = useApp()
+  const colors = useThemeColors()
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -24,14 +26,14 @@ export default function SplashScreen() {
   }, [state.hasCompletedOnboarding, router])
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, { backgroundColor: colors.background }]}>
       <View style={styles.content}>
         <Image
           source={require('@/assets/images/loading.png')}
           style={styles.illustration}
           resizeMode="contain"
         />
-        <Text style={styles.title}>Shopper</Text>
+        <Text style={[styles.title, { color: colors.text }]}>Shopper</Text>
       </View>
     </View>
   )
@@ -40,7 +42,6 @@ export default function SplashScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: Colors.background,
     alignItems: 'center',
     justifyContent: 'center',
   },
@@ -59,7 +60,6 @@ const styles = StyleSheet.create({
 
   title: {
     ...Typography.textStyles.largeTitle,
-    color: Colors.text,
     fontWeight: Typography.fontWeight.bold,
   },
 })


### PR DESCRIPTION
## Summary
- use `useThemeColors` across multiple pages to apply theme-aware backgrounds and text colors
- replace direct `Colors.background` and `Colors.text` usages in layouts and screens

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b51fdaa8d8832397826db0f27ff6e7