### PR TITLE
Handle missing category in custom items lookup

### DIFF
--- a/context/AppContext.tsx
+++ b/context/AppContext.tsx
@@ -486,7 +486,10 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({
       return state.customItems.filter(item => !item.category)
     }
     const category = state.categories.find(cat => cat.id === categoryId)
-    return state.customItems.filter(item => item.category === category?.name)
+    if (!category) {
+      return []
+    }
+    return state.customItems.filter(item => item.category === category.name)
   }
 
   const getMostUsedCustomItems = (limit = 10): CustomItem[] => {


### PR DESCRIPTION
## Summary
- return empty list if getCustomItemsByCategory receives a missing category

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b51fdd68f4832398b19e05e6ba6c61