### PR TITLE
fix: apply correct colors for light theme

### DIFF
--- a/app/(tabs)/explore.tsx
+++ b/app/(tabs)/explore.tsx
@@ -7,7 +7,6 @@ import ParallaxScrollView from '@/components/ParallaxScrollView'
 import { ThemedText } from '@/components/ThemedText'
 import { ThemedView } from '@/components/ThemedView'
 import { IconSymbol } from '@/components/ui/IconSymbol'
-import { Colors } from '@/constants/Colors'
 import { useThemeColors } from '@/hooks/useThemeColors'
 
 export default function TabTwoScreen() {
@@ -15,8 +14,8 @@ export default function TabTwoScreen() {
   return (
     <ParallaxScrollView
       headerBackgroundColor={{
-        light: Colors.light.background,
-        dark: Colors.dark.background,
+        light: colors.background,
+        dark: colors.background,
       }}
       headerImage={
         <IconSymbol

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -5,15 +5,13 @@ import { HelloWave } from '@/components/HelloWave'
 import ParallaxScrollView from '@/components/ParallaxScrollView'
 import { ThemedText } from '@/components/ThemedText'
 import { ThemedView } from '@/components/ThemedView'
-import { Colors } from '@/constants/Colors'
+import { useThemeColor } from '@/hooks/useThemeColor'
 
 export default function HomeScreen() {
+  const background = useThemeColor({}, 'background')
   return (
     <ParallaxScrollView
-      headerBackgroundColor={{
-        light: Colors.light.background,
-        dark: Colors.dark.background,
-      }}
+      headerBackgroundColor={{ light: background, dark: background }}
       headerImage={
         <Image
           source={require('@/assets/images/partial-react-logo.png')}

--- a/components/Collapsible.tsx
+++ b/components/Collapsible.tsx
@@ -5,14 +5,12 @@ import { ThemedText } from '@/components/ThemedText'
 import { ThemedView } from '@/components/ThemedView'
 import { IconSymbol } from '@/components/ui/IconSymbol'
 import { Colors } from '@/constants/Colors'
-import { useColorScheme } from '@/hooks/useColorScheme'
 
 export function Collapsible({
   children,
   title,
 }: PropsWithChildren & { title: string }) {
   const [isOpen, setIsOpen] = useState(false)
-  const theme = useColorScheme() ?? 'light'
 
   return (
     <ThemedView>
@@ -25,11 +23,7 @@ export function Collapsible({
           name="chevron.right"
           size={18}
           weight="medium"
-          color={
-            theme === 'light'
-              ? Colors.light.textSecondary
-              : Colors.dark.textSecondary
-          }
+          color={Colors.textSecondary}
           style={{ transform: [{ rotate: isOpen ? '90deg' : '0deg' }] }}
         />
 

--- a/constants/Colors.ts
+++ b/constants/Colors.ts
@@ -44,10 +44,14 @@ const darkColors = {
 const Colors = {
   light: lightColors,
   dark: darkColors,
-  ...darkColors, // default for backward compatibility
-} as const
+  ...lightColors, // default to light; will be updated on theme changes
+}
 
 export type ThemeColors = typeof lightColors
+
+export function applyTheme(theme: 'light' | 'dark') {
+  Object.assign(Colors, Colors[theme])
+}
 
 export { Colors }
 export default Colors

--- a/context/ThemeContext.tsx
+++ b/context/ThemeContext.tsx
@@ -5,6 +5,8 @@ import {
   useColorScheme as useRNColorScheme,
 } from 'react-native'
 
+import { applyTheme } from '@/constants/Colors'
+
 export type ThemePreference = 'light' | 'dark' | 'system'
 
 interface ThemeContextValue {
@@ -42,6 +44,10 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({
   }
 
   const theme = themePreference === 'system' ? systemScheme : themePreference
+
+  useEffect(() => {
+    applyTheme(theme)
+  }, [theme])
 
   return (
     <ThemeContext.Provider


### PR DESCRIPTION
## Summary
- ensure color palette defaults to light and syncs with theme changes
- update ThemeContext to apply palette when theme preference changes
- adjust interface components to read colors from active theme

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_68b52a05de9c83239c16274c1a8c96c5