### PR TITLE
fix: apply correct colors for light theme

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -6,6 +6,7 @@ import {
 import { useFonts } from 'expo-font'
 import { Stack } from 'expo-router'
 import { StatusBar } from 'expo-status-bar'
+import { useMemo } from 'react'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import 'react-native-reanimated'
 
@@ -14,37 +15,27 @@ import { AppProvider } from '@/context/AppContext'
 import { ThemeProvider as ThemePreferenceProvider } from '@/context/ThemeContext'
 import { useColorScheme } from '@/hooks/useColorScheme'
 
-const customDarkTheme = {
-  ...DarkTheme,
-  colors: {
-    ...DarkTheme.colors,
-    background: Colors.dark?.background ?? Colors.background,
-    card: Colors.dark?.surface ?? Colors.surface,
-    text: Colors.dark?.text ?? Colors.text,
-    border: Colors.dark?.border ?? Colors.border,
-    notification: Colors.dark?.primary ?? Colors.primary,
-    primary: Colors.dark?.primary ?? Colors.primary,
-  },
-}
-
-const customLightTheme = {
-  ...DefaultTheme,
-  colors: {
-    ...DefaultTheme.colors,
-    background: Colors.light?.background ?? Colors.background,
-    card: Colors.light?.surface ?? Colors.surface,
-    text: Colors.light?.text ?? Colors.text,
-    border: Colors.light?.border ?? Colors.border,
-    notification: Colors.light?.primary ?? Colors.primary,
-    primary: Colors.light?.primary ?? Colors.primary,
-  },
-}
-
 function AppInner() {
   const colorScheme = useColorScheme()
-  const theme = colorScheme === 'dark' ? customDarkTheme : customLightTheme
+  const navigationTheme = useMemo(() => {
+    const base = colorScheme === 'dark' ? DarkTheme : DefaultTheme
+    const schemeColors = Colors[colorScheme]
+    return {
+      ...base,
+      colors: {
+        ...base.colors,
+        background: schemeColors.background,
+        card: schemeColors.surface,
+        text: schemeColors.text,
+        border: schemeColors.border,
+        notification: schemeColors.primary,
+        primary: schemeColors.primary,
+      },
+    }
+  }, [colorScheme])
+
   return (
-    <NavigationThemeProvider value={theme}>
+    <NavigationThemeProvider value={navigationTheme}>
       <Stack screenOptions={{ headerShown: false }}>
         <Stack.Screen name="index" />
         <Stack.Screen name="(onboarding)" />

--- a/components/ui/ArchiveListCard.tsx
+++ b/components/ui/ArchiveListCard.tsx
@@ -1,10 +1,11 @@
 import { Ionicons } from '@expo/vector-icons'
-import React from 'react'
+import React, { useMemo } from 'react'
 import { View, Text, TouchableOpacity, StyleSheet, Alert } from 'react-native'
 
-import { Colors } from '@/constants/Colors'
+import { type ThemeColors } from '@/constants/Colors'
 import { Spacing, BorderRadius, Shadows } from '@/constants/Layout'
 import { Typography } from '@/constants/Typography'
+import { useThemeColors } from '@/hooks/useThemeColors'
 import { ShoppingList } from '@/types'
 import { HapticFeedback } from '@/utils/haptics'
 
@@ -34,6 +35,8 @@ export function ArchiveListCard({
 }: ArchiveListCardProps) {
   const completedCount = getCompletedCount(item)
   const totalCount = item.items.length
+  const colors = useThemeColors()
+  const styles = useMemo(() => createStyles(colors), [colors])
 
   const handleRestoreList = () => {
     Alert.alert(
@@ -118,9 +121,9 @@ export function ArchiveListCard({
             <Ionicons
               name="arrow-undo-outline"
               size={16}
-              color={Colors.primary}
+              color={colors.primary}
             />
-            <Text style={[styles.actionText, { color: Colors.primary }]}>
+            <Text style={[styles.actionText, { color: colors.primary }]}>
               Restore
             </Text>
           </TouchableOpacity>
@@ -129,8 +132,8 @@ export function ArchiveListCard({
             style={styles.actionButton}
             onPress={handleDeletePermanently}
           >
-            <Ionicons name="trash-outline" size={16} color={Colors.error} />
-            <Text style={[styles.actionText, { color: Colors.error }]}>
+            <Ionicons name="trash-outline" size={16} color={colors.error} />
+            <Text style={[styles.actionText, { color: colors.error }]}>
               Delete
             </Text>
           </TouchableOpacity>
@@ -140,72 +143,73 @@ export function ArchiveListCard({
   )
 }
 
-const styles = StyleSheet.create({
-  listCard: {
-    backgroundColor: Colors.surface,
-    borderRadius: BorderRadius.md,
-    marginBottom: Spacing.md,
-    ...Shadows.medium,
-  },
+const createStyles = (colors: ThemeColors) =>
+  StyleSheet.create({
+    listCard: {
+      backgroundColor: colors.surface,
+      borderRadius: BorderRadius.md,
+      marginBottom: Spacing.md,
+      ...Shadows.medium,
+    },
 
-  deletedCard: {
-    opacity: 0.8,
-  },
+    deletedCard: {
+      opacity: 0.8,
+    },
 
-  listCardContent: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    padding: Spacing.md,
-  },
+    listCardContent: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      padding: Spacing.md,
+    },
 
-  listCardLeft: {
-    flex: 1,
-  },
+    listCardLeft: {
+      flex: 1,
+    },
 
-  listCardRight: {
-    marginLeft: Spacing.md,
-  },
+    listCardRight: {
+      marginLeft: Spacing.md,
+    },
 
-  listTitle: {
-    ...Typography.textStyles.subtitle,
-    color: Colors.text,
-    marginBottom: Spacing.xs,
-  },
+    listTitle: {
+      ...Typography.textStyles.subtitle,
+      color: colors.text,
+      marginBottom: Spacing.xs,
+    },
 
-  listPreview: {
-    ...Typography.textStyles.caption,
-    color: Colors.textSecondary,
-    marginBottom: Spacing.xs,
-  },
+    listPreview: {
+      ...Typography.textStyles.caption,
+      color: colors.textSecondary,
+      marginBottom: Spacing.xs,
+    },
 
-  archivedDate: {
-    ...Typography.textStyles.caption,
-    color: Colors.textTertiary,
-    fontSize: 11,
-  },
+    archivedDate: {
+      ...Typography.textStyles.caption,
+      color: colors.textTertiary,
+      fontSize: 11,
+    },
 
-  deletedDate: {
-    ...Typography.textStyles.caption,
-    color: Colors.error,
-    fontSize: 11,
-  },
+    deletedDate: {
+      ...Typography.textStyles.caption,
+      color: colors.error,
+      fontSize: 11,
+    },
 
-  listActions: {
-    flexDirection: 'row',
-    borderTopWidth: 1,
-    borderTopColor: Colors.border,
-    paddingHorizontal: Spacing.md,
-    paddingVertical: Spacing.sm,
-  },
+    listActions: {
+      flexDirection: 'row',
+      borderTopWidth: 1,
+      borderTopColor: colors.border,
+      paddingHorizontal: Spacing.md,
+      paddingVertical: Spacing.sm,
+    },
 
-  actionButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginRight: Spacing.lg,
-  },
+    actionButton: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      marginRight: Spacing.lg,
+    },
 
-  actionText: {
-    ...Typography.textStyles.caption,
-    marginLeft: Spacing.xs,
-  },
-})
+    actionText: {
+      ...Typography.textStyles.caption,
+      marginLeft: Spacing.xs,
+    },
+  })

--- a/constants/Colors.ts
+++ b/constants/Colors.ts
@@ -44,10 +44,14 @@ const darkColors = {
 const Colors = {
   light: lightColors,
   dark: darkColors,
-  ...darkColors, // default for backward compatibility
-} as const
+  ...lightColors, // default to light; will be updated on theme changes
+}
 
 export type ThemeColors = typeof lightColors
+
+export function applyTheme(theme: 'light' | 'dark') {
+  Object.assign(Colors, Colors[theme])
+}
 
 export { Colors }
 export default Colors

--- a/context/ThemeContext.tsx
+++ b/context/ThemeContext.tsx
@@ -5,6 +5,8 @@ import {
   useColorScheme as useRNColorScheme,
 } from 'react-native'
 
+import { applyTheme } from '@/constants/Colors'
+
 export type ThemePreference = 'light' | 'dark' | 'system'
 
 interface ThemeContextValue {
@@ -42,6 +44,10 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({
   }
 
   const theme = themePreference === 'system' ? systemScheme : themePreference
+
+  useEffect(() => {
+    applyTheme(theme)
+  }, [theme])
 
   return (
     <ThemeContext.Provider


### PR DESCRIPTION
## Summary
- recalculate navigation theme using active palette
- refactor ArchiveListCard to build styles from current theme

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_68b52a05de9c83239c16274c1a8c96c5